### PR TITLE
Update README to use blockquote instead of node notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,9 @@ npx qiita new 記事のファイルのベース名
 
 記事のファイルのベース名は自由に変更が可能です。
 
-:::note warn
-記事のファイル名を`newArticle001.md`にしたい場合は`newArticle001`にします。
-
-例): `$ npx qiita new newArticle001`
-:::
+> 記事のファイル名を`newArticle001.md`にしたい場合は`newArticle001`にします。
+>
+> 例): `$ npx qiita new newArticle001`
 
 作成された記事ファイルの中身は次のようになっています。
 


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

Note notation is not available on GitHub.
Therefore, replace note notation in README with another notation.

## How

- Rewrote note notation in README to blockquote.

## Why

## Refs
