### PR TITLE
qiita.config.jsonを使って、設定を変更できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ npm install @qiita/qiita-cli@latest
 
 ## Qiita CLI のセットアップ方法について
 
+### init コマンドを実行する
+
+以下のコマンドを実行することで、
+
+- .gitignore
+- GitHub Actions のワークフローファイル
+  - 「GitHub で記事を管理する」の項目を参照
+- ユーザー設定ファイル（qiita.config.json）
+  - 「ユーザー設定ファイルについて」の項目を参照
+
+が生成されます。
+
+```console
+npx qiita init
+```
+
 ### Qiita のトークンを発行する
 
 以下の流れでトークンを発行してください。
@@ -161,17 +177,6 @@ Qiita CLI、Qiita Preview から記事の削除はできません。
 
 ## GitHub で記事を管理する
 
-以下のコマンドを実行することで、
-
-- .gitignore
-- GitHub Actions のワークフローファイル
-
-が生成されます。
-
-```console
-npx qiita init
-```
-
 ### GitHub の設定について
 
 以下の流れで設定を行うことで、GitHub の特定のブランチにコミットしたタイミングで記事の投稿や更新を行うことが可能になります。
@@ -204,19 +209,37 @@ npx qiita pull
 
 ### version
 
-qiita-cli のバージョンを確認できます。
+Qiita CLI のバージョンを確認できます。
 
 ```console
 npx qiita version
 ```
 
+## ユーザー設定ファイルについて
+
+`npx qiita init`コマンドで生成される`qiita.config.json`について説明します。
+このファイルを用いて、Qiita CLI の設定を行うことができます。
+設定できるオプションは以下の通りです。
+
+- includePrivate: 限定共有記事を含めるかどうかを選べます。デフォルトは`false`です。
+
 ## オプション
+
+### --credential \<credential_dir>
+
+Qiita CLI の認証情報（`credentials.json`）を配置する・しているディレクトリを指定できます。
+デフォルトでは`$XDG_CONFIG_HOME/qiita-cli`もしくは`$HOME/.config/qiita-cli`になっています。
+
+```console
+npx qiita login ---credential ./my_conf/
+npx qiita preview --credential ./my_conf/
+```
 
 ### --config \<config_dir>
 
-qiita-cli の設定情報（`credentials.json`）を配置する・しているディレクトリを指定できます。
+Qiita CLI の設定情報（`qiita.config.json`）を配置する・しているディレクトリを指定できます。
 
-デフォルトでは`$XDG_CONFIG_HOME/qiita-cli`もしくは`$HOME/.config/qiita-cli`になっています。
+デフォルトでは、カレントディレクトリになります。
 
 例）
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -9,18 +9,21 @@ COMMAND:
   publish <basename> ...  記事を投稿、更新
   publish --all           全ての記事を投稿、更新
   pull                    記事ファイルをQiitaと同期
-  version                 qiita-cliのバージョンを表示
+  version                 Qiita CLIのバージョンを表示
   help                    ヘルプを表示
 
 OPTIONS:
-  --config <config_dir>
-    qiita-cliの設定情報を配置するディレクトリを指定
+  --credential <credential_dir>
+    Qiita CLIの認証情報を配置するディレクトリを指定
 
   --root <root_dir>
     記事ファイルをダウンロードするディレクトリを指定
 
   --verbose
     詳細表示オプションを有効
+
+  --config
+    設定ファイルを配置するディレクトリを指定
 
 詳細についてはReadme(https://github.com/increments/qiita-cli)をご覧ください
 `;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { config } from "../lib/config";
 
 export const init = async () => {
   const rootDir = process.cwd();
@@ -48,6 +49,18 @@ jobs:
 node_modules
 `;
   writeFile(gitignoreFilePath, gitignoreFileContent);
+
+  const userConfigFilePath = config.getUserConfigFilePath();
+  const userConfigDir = config.getUserConfigDir();
+  if (!fs.existsSync(userConfigFilePath)) {
+    fs.mkdirSync(userConfigDir, { recursive: true });
+  }
+  const userConfigFileContent = JSON.stringify(
+    await config.getUserConfig(),
+    null,
+    2
+  );
+  writeFile(userConfigFilePath, userConfigFileContent);
 };
 
 const writeFile = (path: string, content: string) => {

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -57,13 +57,13 @@ jest.mock("node:fs/promises", () => {
 });
 
 describe("config", () => {
-  describe("#getConfigDir", () => {
+  describe("#getCredentialDir", () => {
     beforeEach(() => {
       config.load({});
     });
 
     it("returns default path", () => {
-      expect(config.getConfigDir()).toEqual(
+      expect(config.getCredentialDir()).toEqual(
         "/home/test-user/.config/qiita-cli"
       );
     });
@@ -71,13 +71,13 @@ describe("config", () => {
     describe("with options", () => {
       beforeEach(() => {
         config.load({
-          configDir: "my-config",
+          credentialDir: "my-credential",
         });
       });
 
       it("returns customized path", () => {
-        expect(config.getConfigDir()).toEqual(
-          "/home/test-user/qiita-articles/my-config"
+        expect(config.getCredentialDir()).toEqual(
+          "/home/test-user/qiita-articles/my-credential"
         );
       });
     });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,40 +5,40 @@ import process from "node:process";
 import { configDebugger } from "./debugger";
 
 interface Options {
-  configDir?: string;
+  credentialDir?: string;
   profile?: string;
   itemsRootDir?: string;
 }
 
 class Config {
-  private configDir?: string;
+  private credentialDir?: string;
   private itemsRootDir?: string;
   private credential?: Credential;
 
   constructor() {}
 
   load(options: Options) {
-    this.configDir = this.resolveConfigDir(options.configDir);
+    this.credentialDir = this.resolveConfigDir(options.credentialDir);
     this.itemsRootDir = this.resolveItemsRootDir(options.itemsRootDir);
     this.credential = new Credential({
-      credentialDir: this.configDir,
+      credentialDir: this.credentialDir,
       profile: options.profile,
     });
 
     configDebugger(
       "load",
       JSON.stringify({
-        configDir: this.configDir,
+        credentialDir: this.credentialDir,
         itemsRootDir: this.itemsRootDir,
       })
     );
   }
 
-  getConfigDir() {
-    if (!this.configDir) {
-      throw new Error("configDir is undefined");
+  getCredentialDir() {
+    if (!this.credentialDir) {
+      throw new Error("credentialDir is undefined");
     }
-    return this.configDir;
+    return this.credentialDir;
   }
 
   // TODO: filesystemrepo 側にあるべきか確認
@@ -63,19 +63,19 @@ class Config {
     return this.credential.setCredential(credential);
   }
 
-  private resolveConfigDir(configDirPath?: string) {
+  private resolveConfigDir(credentialDirPath?: string) {
     const packageName = "qiita-cli";
 
     if (process.env.XDG_CONFIG_HOME) {
-      const configDir = process.env.XDG_CONFIG_HOME;
-      return path.join(configDir, packageName);
+      const credentialDir = process.env.XDG_CONFIG_HOME;
+      return path.join(credentialDir, packageName);
     }
-    if (!configDirPath) {
+    if (!credentialDirPath) {
       const homeDir = os.homedir();
       return path.join(homeDir, ".config", packageName);
     }
 
-    return this.resolveFullPath(configDirPath);
+    return this.resolveFullPath(credentialDirPath);
   }
 
   private resolveItemsRootDir(dirPath?: string) {

--- a/src/lib/sync-articles-from-qiita.ts
+++ b/src/lib/sync-articles-from-qiita.ts
@@ -1,5 +1,6 @@
 import type { QiitaApi } from "../qiita-api";
 import type { FileSystemRepo } from "./file-system-repo";
+import { config } from "./config";
 
 export const syncArticlesFromQiita = async ({
   fileSystemRepo,
@@ -9,12 +10,16 @@ export const syncArticlesFromQiita = async ({
   qiitaApi: QiitaApi;
 }) => {
   const per = 100;
+  const userConfig = await config.getUserConfig();
   for (let page = 1; page <= 100; page += 1) {
     const items = await qiitaApi.authenticatedUserItems(page, per);
     if (items.length <= 0) {
       break;
     }
 
-    await fileSystemRepo.saveItems(items);
+    const result = userConfig.includePrivate
+      ? items
+      : items.filter((item) => !item.private);
+    await fileSystemRepo.saveItems(result);
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ dotenv.config();
 
 const args = arg(
   {
-    "--config": String,
+    "--credential": String,
     "--profile": String,
     "--root": String,
     "--verbose": Boolean,
@@ -29,7 +29,7 @@ if (args["--verbose"]) {
 }
 
 config.load({
-  configDir: args["--config"],
+  credentialDir: args["--credential"],
   profile: args["--profile"],
   itemsRootDir: args["--root"],
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ const args = arg(
   {
     "--credential": String,
     "--profile": String,
+    "--config": String,
     "--root": String,
     "--verbose": Boolean,
   },
@@ -32,6 +33,7 @@ config.load({
   credentialDir: args["--credential"],
   profile: args["--profile"],
   itemsRootDir: args["--root"],
+  userConfigDir: args["--config"],
 });
 
 exec(commandName, commandArgs);


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
- https://github.com/increments/qiita-cli/pull/5 への対応を行う

## How
- `--config`オプションを`--credential`オプションに変更した
- `qiita init`で`qiita.config.json`を作成するようにした
- `qiita.config.json`を用いて限定共有記事を取得するかどうかを選べるようにした（デフォルトは`false`にした）
- `--config`オプションで`qiita.config.json`のパスを指定できるようにした

## Why
- 現在はリポジトリなどでも参照できる形で設定をかける場所がなかった。新たにqiita.config.jsonを使うことで、細かい設定を行えるようにした
- 今までは`--config`を用いてローカルマシン上の認証情報を置く場所を指定できたが、`config`という名前がバッティングするので、元々`--config`となっていたものを`--credential`に変更した

## Refs
https://github.com/increments/qiita-cli/pull/5