### PR TITLE
Add force option to pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ Qiita 上で更新を行い、手元で変更を行っていない記事ファ�
 npx qiita pull
 ```
 
+`--force`オプションを用いることで、記事ファイルをを全て強制的に Qiita と同期します。
+
+```console
+npx qiita pull --force
+# -f は --force のエイリアスとして使用できます。
+npx qiita pull -f
+```
+
 ### version
 
 Qiita CLI のバージョンを確認できます。

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -7,12 +7,19 @@ import { QiitaApi } from "../qiita-api";
 import { startLocalChangeWatcher, startServer } from "../server/app";
 
 export const pull = async (argv: string[]) => {
-  const args = arg({}, { argv });
+  const args = arg(
+    {
+      "--force": Boolean,
+      "-f": "--force",
+    },
+    { argv }
+  );
 
   const qiitaApi = await getQiitaApiInstance();
   const fileSystemRepo = await getFileSystemRepo();
+  const isLocalUpdate = args["--force"];
 
-  await syncArticlesFromQiita({ fileSystemRepo, qiitaApi });
+  await syncArticlesFromQiita({ fileSystemRepo, qiitaApi, isLocalUpdate });
   console.log("Sync local articles from Qiita");
   console.log("Successful!");
 };

--- a/src/lib/file-system-repo.ts
+++ b/src/lib/file-system-repo.ts
@@ -276,9 +276,9 @@ export class FileSystemRepo {
     }
   }
 
-  async saveItems(items: Item[]) {
+  async saveItems(items: Item[], isLocalUpdate: boolean = false) {
     const promises = items.map(async (item) => {
-      await this.syncItem(item);
+      await this.syncItem(item, false, isLocalUpdate);
     });
 
     await Promise.all(promises);

--- a/src/lib/sync-articles-from-qiita.ts
+++ b/src/lib/sync-articles-from-qiita.ts
@@ -5,9 +5,11 @@ import { config } from "./config";
 export const syncArticlesFromQiita = async ({
   fileSystemRepo,
   qiitaApi,
+  isLocalUpdate = false,
 }: {
   fileSystemRepo: FileSystemRepo;
   qiitaApi: QiitaApi;
+  isLocalUpdate?: boolean;
 }) => {
   const per = 100;
   const userConfig = await config.getUserConfig();
@@ -20,6 +22,6 @@ export const syncArticlesFromQiita = async ({
     const result = userConfig.includePrivate
       ? items
       : items.filter((item) => !item.private);
-    await fileSystemRepo.saveItems(result);
+    await fileSystemRepo.saveItems(result, isLocalUpdate);
   }
 };


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
- `qiita pull --force` オプション、エイリアスとなる`-f`を追加しました。
    - `public` 配下のmarkdownファイルを全て更新します。
- オプションの追加をReadmeに記載しました。

## How
- `qiita pull`コマンドで `--force` オプション、`-f` オプションを受け付けるように変更
    - `syncArticlesFromQiita` の関数に、`isLocalUpdate`引数を追加
    - 引数によって、`public` 配下のmarkdownファイルを全て更新するかを条件分岐しています

## Why
- 現在の`qiita pull` コマンドは、差分のあるmarkdownファイルを更新しないようになっている
- GitHub Actionsなどで`qiita pull` コマンドを実行して、markdownをリモートに同期させたい時、差分があると見なされうまく更新できないことがありました。
    - こちらを解消したく、`--force`コマンドがあると良いのではと考えました。

## Refs
- コーディング規約、修正などあれば指摘いただくか、修正いただければと思います:bow:
