### PR TITLE
Delete setup GitHub Actions job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,28 +22,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  setup:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    strategy:
-      matrix:
-        node:
-          - "18.0.0"
-          - "18.16.0"
-    needs:
-      - check_test_execution_conditions
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-      - run: yarn install
-
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
-      - setup
+      - check_test_execution_conditions
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -61,7 +44,7 @@ jobs:
           - "18.0.0"
           - "18.16.0"
     needs:
-      - setup
+      - check_test_execution_conditions
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -74,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
-      - setup
+      - check_test_execution_conditions
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
Improve GitHub Actions workflow with caching and job consolidation
- remove "setup" job

## How

## Why
Dependencies of the lint, test and build jobs: 
all of these jobs currently depend on the setup job, but it appears that the setup job does not specifically create any shared state.


## Refs
