### PR TITLE
Add port option to qiita.config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 node_modules
 tmp
+.github/workflows/publish.yml

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ npx qiita version
 設定できるオプションは以下の通りです。
 
 - includePrivate: 限定共有記事を含めるかどうかを選べます。デフォルトは`false`です。
+- port: `qiita preview`コマンドで利用するポートを指定できます。デフォルトは`8888`です。
 
 ## オプション
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -224,6 +224,7 @@ describe("config", () => {
       beforeEach(() => {
         const userConfigData = {
           includePrivate: true,
+          port: 9999,
         };
         resetFiles();
         setFile(userConfigFilePath, JSON.stringify(userConfigData, null, 2));
@@ -233,6 +234,7 @@ describe("config", () => {
         const userConfig = await config.getUserConfig();
         expect(userConfig).toStrictEqual({
           includePrivate: true,
+          port: 9999,
         });
       });
     });
@@ -246,6 +248,7 @@ describe("config", () => {
         const userConfig = await config.getUserConfig();
         expect(userConfig).toStrictEqual({
           includePrivate: false,
+          port: 8888,
         });
       });
     });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,6 +14,7 @@ interface Options {
 
 type UserConfig = {
   includePrivate: boolean;
+  port: number;
 };
 
 class Config {
@@ -106,6 +107,7 @@ class Config {
   async getUserConfig() {
     const defaultConfig = {
       includePrivate: false,
+      port: 8888,
     } as UserConfig;
 
     if (fsSync.existsSync(this.getUserConfigFilePath())) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -9,6 +9,7 @@ import { AssetsRouter } from "./api/assets";
 import { EmojiRouter } from "./api/emoji";
 import { ItemsRouter } from "./api/items";
 import { ReadmeRouter } from "./api/readme";
+import { config } from "../lib/config";
 
 export async function startServer() {
   const app = express();
@@ -30,9 +31,8 @@ export async function startServer() {
   app.use("*", express.static(path.join(__dirname, "../public/index.html")));
 
   const server = createServer(app);
-  const port = process.env.QIITA_CLI_PORT
-    ? parseInt(process.env.QIITA_CLI_PORT, 10)
-    : 8888;
+  const userConfig = await config.getUserConfig();
+  const port = userConfig.port;
   const host = "localhost";
 
   return new Promise<Server>((resolve) => {


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
qiita.config.jsonでポート番号を指定できるようにした。
`port`でポート番号を指定することができる（デフォルトは8888）
環境変数でポート番号を指定することができる仕様を削除した。

## Why
- 環境変数によるポート指定は開発用に用意していたもので、ユーザーが使うことを想定していなかったため削除した


## Refs
