### PR TITLE
add "root" option to actions/publish

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -5,7 +5,7 @@ author: "Qiita Inc."
 inputs:
   root:
     required: false
-    default: '.'
+    default: "."
     description: "Root directory path"
   qiita-token:
     required: true

--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -3,6 +3,10 @@ description: "Publish articles to Qiita using qiita-cli"
 author: "Qiita Inc."
 
 inputs:
+  root:
+    required: false
+    default: '.'
+    description: "Root directory path"
   qiita-token:
     required: true
     description: "Qiita API token"
@@ -17,13 +21,13 @@ runs:
       run: npm install -g @qiita/qiita-cli@v1.0.0
       shell: bash
     - name: Publish articles
-      run: qiita publish --all
+      run: qiita publish --all --root ${{ inputs.root }}
       env:
         QIITA_TOKEN: ${{ inputs.qiita-token }}
       shell: bash
     - name: Commit and push diff # Not executed recursively even if `push` is triggered. See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
       run: |
-        git add public/*
+        git add ${{ inputs.root }}/public/*
         if ! git diff --staged --exit-code --quiet; then
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## What
actions/publish に `root` オプションを追加しました。

[`root` オプションを指定しない場合（デフォルト）](https://github.com/MxShun/qiita-content/commit/76bb66d5a029af859081a6398b5ce5a0c074e3fd)：https://github.com/MxShun/qiita-content/commit/b5365bbb60fb1bc93d0fade4775fc67f597f96c3
[`root` オプションを指定した場合](https://github.com/MxShun/qiita-content/commit/3a8cca1bb33ed037e4c9f0afff6f8a92a3463862)：https://github.com/MxShun/qiita-content/commit/0673b42852eddf4eab5389fee5139b2247bb512a

## How
actions/publish に任意 inputs の `root` を追加しました。
デフォルトではカレントディレクトリ `.` が指定されます。（後方互換性あり。）

## Why
actions/publish により強制的にカレントディレクトリに記事ファイルがダウンロードされる。
`root` オプションを利用して記事を管理する場合、記事ファイルが `root` で指定したディレクトリと二重管理になるため。

## Refs
