### PR TITLE
Add root option to github action template

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -30,6 +30,7 @@ jobs:
       - uses: increments/qiita-cli/actions/publish@v1
         with:
           qiita-token: \${{ secrets.QIITA_TOKEN }}
+          root: "."
 `;
 
 const rootDir = process.cwd();


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
- https://github.com/increments/qiita-cli/pull/51 で追加されたaction.ymlのオプションへの対応を行う

## How
- action.ymlで`root`を指定できるようになったため、生成するGitHub Actionsのテンプレートにも`root`を追加した
    - デフォルト値をaction.ymlで設定しているため、過去のバージョンで生成されたGitHub Actionsを利用していても問題なく動く

## Why

## Refs
