### PR TITLE
Fix versioning strategy of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,4 @@ updates:
       day: "monday"
       time: "14:00"
       timezone: "Asia/Tokyo"
+    versioning-strategy: increase


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

dependabotのPull Requestで`package.json`も更新されるようにした。

## How

`dependabot.yml`のnpmの`versioning-strategy`を`increase`に変更した。

## Why

Qiita CLIはツールとして使ってもらうものであるため、
依存パッケージのバージョンがユーザーそれぞれで異なることによって意図しない挙動が起こるのを避けたいため。

## Refs

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy