### PR TITLE
Fix publish command

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -105,7 +105,7 @@ export const publish = async (argv: string[]) => {
         organizationUrlName: item.organizationUrlName,
         slide: item.slide,
       });
-      fileSystemRepo.updateItemUuid(item.name, responseItem.id);
+      await fileSystemRepo.updateItemUuid(item.name, responseItem.id);
 
       console.log(`Posted: ${item.name} -> ${responseItem.id}`);
     }


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
- Qiita CLI の publish コマンドを実行すると別のファイルが生成される不具合の修正を行なった

## How
- 記事ファイルの`id`を書き換える前に、`id`を取得しようとする場合があるのでawaitを記事の`id`を変更する関数に指定した。
## Why
- Discussionsより問い合わせがあった内容の修正

**再現手順**
```
1. `npx qiita new newArticleBase` で新しいファイルを作る
2. `public/newArticleBase.md` を編集する
3. `npx qiita publish newArticleBase` で記事を投稿する
4. `public/newArticleBase.md` とは別に `public/{hashId}.md` が作られる
```
- ref:https://github.com/increments/qiita-discussions/discussions/537
## Refs
