### PR TITLE
Fix command line argument typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Qiita CLI の認証情報（`credentials.json`）を配置する・している�
 デフォルトでは`$XDG_CONFIG_HOME/qiita-cli`もしくは`$HOME/.config/qiita-cli`になっています。
 
 ```console
-npx qiita login ---credential ./my_conf/
+npx qiita login --credential ./my_conf/
 npx qiita preview --credential ./my_conf/
 ```
 


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

README内のコマンドをtypoしているため修正する

## How

## Why

## Refs

- [READMEのコマンド修正依頼 · increments/qiita-discussions · Discussion #550](https://github.com/increments/qiita-discussions/discussions/550)