### PR TITLE
Update from node18.0.0 to 18.12.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - "18.0.0"
-          - "18.16.0"
+          - "18.12.0"
+          - "18.19.0"
+          - "20.11.0"
     needs:
       - check_test_execution_conditions
     steps:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Qiita の Markdown 記法については[Markdown 記法 チートシート](htt
 
 ### 1. 事前準備
 
-Qiita CLI を使うには `Node.js 18.0.0` 以上が必要です。  
+Qiita CLI を使うには `Node.js 18.12.0` 以上が必要です。  
 Node.js をはじめて使う場合はインストールする必要があります。
 
 ### 2. Qiita CLI をインストールする

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "packageManager": "yarn@1.22.19",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.12.0"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

パッケージのアップデートの際にNodeバージョンが古くアップデートに支障が出たため最低バージョンを更新しようと思います

## How

- Node18.0.0 > 18.12.0 にした
- READMEに記載していた最低バージョンの表記を修正した
- CI時のテストのバージョンを変更した
  - 合わせて現時点の最新版のテストするように修正した
    - https://nodejs.org/en/about/previous-releases
    - Node18.16.0 > 18.19.0
    - Node20.11.0

## Why

## Refs

- https://github.com/increments/qiita-cli/pull/91
