### PR TITLE
Fix error message for forbidden error

### DIFF
--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -2,6 +2,7 @@ import {
   QiitaBadRequestError,
   QiitaFetchError,
   QiitaForbiddenError,
+  QiitaForbiddenOrBadRequestError,
   QiitaInternalServerError,
   QiitaNotFoundError,
   QiitaRateLimitError,
@@ -41,6 +42,14 @@ export const handleError = async (error: Error) => {
       console.error(chalk.red.bold("Qiita APIへのリクエストに失敗しました"));
       console.error(
         chalk.red("  Qiitaのアクセストークンが正しいかご確認ください"),
+      );
+      console.error(chalk.red(""));
+      break;
+    case QiitaForbiddenOrBadRequestError.name:
+      console.error(chalk.red.bold("Qiita APIへのリクエストに失敗しました"));
+      console.error(chalk.red("  記事ファイルに不備がないかご確認ください"));
+      console.error(
+        chalk.red("  または、Qiitaのアクセストークンが正しいかご確認ください"),
       );
       console.error(chalk.red(""));
       break;

--- a/src/qiita-api/errors.ts
+++ b/src/qiita-api/errors.ts
@@ -53,3 +53,11 @@ export class QiitaUnknownError extends Error {
     this.name = "QiitaUnknownError";
   }
 }
+
+export class QiitaForbiddenOrBadRequestError extends Error {
+  constructor(message: string, options?: { cause?: Error }) {
+    // @ts-expect-error This error is fixed in ES2022.
+    super(message, options);
+    this.name = "QiitaForbiddenOrBadRequestError";
+  }
+}


### PR DESCRIPTION
## What

- publish コマンドで API が Forbidden を返した際のエラーメッセージを修正しました。

| before | after |
| --- | --- |
| ![image](https://github.com/increments/qiita-cli/assets/34445284/8a3e7a60-7720-4749-aefb-8a9e8ee0ceb2) | ![image](https://github.com/increments/qiita-cli/assets/34445284/89a94930-5be4-4f78-bf8d-640558ae80f3) |

## Why

- 記事ファイルに不備がある場合に API が Forbidden を返す可能性があるため。
    - 例
        - private を false から true に変更しようとしたとき
        - タグにスペースが含まれているとき

## Refs

- https://github.com/increments/qiita-discussions/discussions/561
- https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-installerrorcause