### PR TITLE
Fix husky setting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn run lint-staged

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint:eslint:fix": "eslint --fix",
     "lint:eslint": "eslint .",
     "lint:typecheck": "tsc --noEmit",
-    "prepare": "husky install",
+    "prepare": "husky",
     "qiita": "node dist/main.js",
     "test": "jest"
   },


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

husky v9で以下の変更があったので、huskyの設定を更新する。

- `husky install`がdeprecatedになった
    - https://github.com/typicode/husky/releases/tag/v9.0.1
- `.husky/pre-commit`のshebang等が不要になった
    - https://github.com/typicode/husky/releases/tag/v9.0.1 の`How to Migrate`
    - husky v9.1.2からdeprecatedであることのメッセージが表示されるようになる様
        - https://github.com/typicode/husky/releases/tag/v9.1.2
        - https://github.com/typicode/husky/releases/tag/v9.1.1

## Refs

- https://github.com/increments/qiita-cli/pull/105
