### PR TITLE
Release v1.5.0

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         node-version: "20.16.0"
     - name: Install qiita-cli
-      run: npm install -g @qiita/qiita-cli@v1.4.4
+      run: npm install -g @qiita/qiita-cli@v1.5.0
       shell: bash
     - name: Publish articles
       run: qiita publish --all --root ${{ inputs.root }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiita/qiita-cli",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Qiita CLI is a tool that allows you to write, preview and publish articles on Qiita from local environment.",
   "keywords": [
     "Qiita"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

`v1.5.0`をリリースする。変更点は以下。

- https://github.com/increments/qiita-cli/pull/172
    - Qiita CLIのNode.jsのサポートバージョンを`>=v18.18.0`にした

