### PR TITLE
Update workflow to enable to customize commit message

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -10,6 +10,10 @@ inputs:
   qiita-token:
     required: true
     description: "Qiita API token"
+  commit-message:
+    required: false
+    description: "Git commit message"
+    default: "Updated by qiita-cli"
 
 runs:
   using: "composite"
@@ -31,7 +35,7 @@ runs:
         if ! git diff --staged --exit-code --quiet; then
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m 'Updated by qiita-cli'
+          git commit -m ${{ inputs.commit-message }}
           git push
         fi
       shell: bash


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
github workflow にて自動的に push が走った時のコミットメッセージをカスタマイズできるように修正しました

## How
`inputs` に `commit-message` という変数を追加
- この変数は、任意であり、デフォルトは変更前と同じ `Updated by qiita-cli` としています
