### PR TITLE
Add node version for test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           - "18.18.0"
           - "18.20.4"
           - "20.16.0"
+          - "22.14.0"
     needs:
       - check_test_execution_conditions
     steps:


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

- add node version to test matrix
   - 22 is active version

## How

## Why

## Refs

- https://github.com/nodejs/release?tab=readme-ov-file#release-schedule