### PR TITLE
Replace react-router from react-router-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^3.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.4.1",
+    "react-router": "^7.4.1",
     "ts-jest": "^29.3.1",
     "ts-loader": "^9.5.2",
     "typescript": "^5.7.2",

--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { apiItemsUpdatePath, itemsShowPath } from "../../lib/qiita-cli-url";
 import { breakpoint, pointerFine } from "../lib/mixins";
 import { Colors, Typography, Weight, getSpace } from "../lib/variables";

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, ScrollRestoration } from "react-router-dom";
+import { Outlet, ScrollRestoration } from "react-router";
 
 export const Layout = () => {
   return (

--- a/src/client/components/Router.tsx
+++ b/src/client/components/Router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router";
 import { ItemsIndex } from "../pages/items";
 import { ItemsShow } from "../pages/items/show";
 import { Layout } from "./Layout";

--- a/src/client/components/SidebarArticles.tsx
+++ b/src/client/components/SidebarArticles.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { useState, useEffect } from "react";
 import { MaterialSymbol } from "./MaterialSymbol";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { pointerFine } from "../lib/mixins";
 import {
   Colors,

--- a/src/client/components/SidebarContents.tsx
+++ b/src/client/components/SidebarContents.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { itemsIndexPath } from "../../lib/qiita-cli-url";
 import { ItemsIndexViewModel } from "../../lib/view-models/items";
 import { breakpoint, pointerFine, viewport } from "../lib/mixins";

--- a/src/client/pages/items/show.tsx
+++ b/src/client/pages/items/show.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router";
 import { apiItemsShowPath } from "../../../lib/qiita-cli-url";
 import type { ItemsShowViewModel } from "../../../lib/view-models/items";
 import { Article } from "../../components/Article";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5305,14 +5305,7 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-router-dom@^7.4.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.4.1.tgz#fd913abb488364859c343881ecb7b7bc84b902f2"
-  integrity sha512-L3/4tig0Lvs6m6THK0HRV4eHUdpx0dlJasgCxXKnavwhh4tKYgpuZk75HRYNoRKDyDWi9QgzGXsQ1oQSBlWpAA==
-  dependencies:
-    react-router "7.4.1"
-
-react-router@7.4.1:
+react-router@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.4.1.tgz#0e6af1eefb8370d2cd79c961b87708afdb50fe64"
   integrity sha512-Vmizn9ZNzxfh3cumddqv3kLOKvc7AskUT0dC1prTabhiEi0U4A33LmkDOJ79tXaeSqCqMBXBU/ySX88W85+EUg==


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

- replace package react-router from react-router-dom

## How

## Why

- migration v7 from v6

## Refs

- https://react-router-docs-ja.techtalk.jp/upgrading/v6
