### PR TITLE
feat: add filename validation to newArticles command

### DIFF
--- a/src/commands/newArticles.ts
+++ b/src/commands/newArticles.ts
@@ -1,5 +1,6 @@
 import arg from "arg";
 import { getFileSystemRepo } from "../lib/get-file-system-repo";
+import { validateFilename } from "../lib/filename-validator";
 
 export const newArticles = async (argv: string[]) => {
   const args = arg({}, { argv });
@@ -8,6 +9,12 @@ export const newArticles = async (argv: string[]) => {
 
   if (args._.length > 0) {
     for (const basename of args._) {
+      const validation = validateFilename(basename);
+      if (!validation.isValid) {
+        console.error(`Error: ${validation.error}`);
+        continue;
+      }
+
       const createdFileName = await fileSystemRepo.createItem(basename);
       if (createdFileName) {
         console.log(`created: ${createdFileName}.md`);

--- a/src/lib/filename-validator.test.ts
+++ b/src/lib/filename-validator.test.ts
@@ -1,0 +1,73 @@
+import { validateFilename } from "./filename-validator";
+
+describe("validateFilename", () => {
+  it("should accept valid filenames", () => {
+    const validNames = [
+      "test",
+      "test-article",
+      "test_article",
+      "test123",
+      "記事テスト",
+      "article.backup",
+      "my-awesome-article",
+    ];
+
+    validNames.forEach((name) => {
+      const result = validateFilename(name);
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  it("should reject empty or whitespace-only filenames", () => {
+    const invalidNames = ["", " ", "  ", "\t", "\n"];
+
+    invalidNames.forEach((name) => {
+      const result = validateFilename(name);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("Filename is empty");
+    });
+  });
+
+  it("should reject filenames with invalid characters", () => {
+    const invalidNames = [
+      "test<file",
+      "test>file",
+      "test:file",
+      'test"file',
+      "test/file",
+      "test\\file",
+      "test|file",
+      "test?file",
+      "test*file",
+      "test\x00file",
+    ];
+
+    invalidNames.forEach((name) => {
+      const result = validateFilename(name);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe(
+        'Filename contains invalid characters: < > : " / \\ | ? * and control characters',
+      );
+    });
+  });
+
+  it("should reject filenames starting or ending with dots or spaces", () => {
+    const invalidNames = [
+      ".test",
+      "test.",
+      " test",
+      "test ",
+      "..test",
+      "test..",
+    ];
+
+    invalidNames.forEach((name) => {
+      const result = validateFilename(name);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe(
+        "Filename cannot start or end with a dot or space",
+      );
+    });
+  });
+});

--- a/src/lib/filename-validator.ts
+++ b/src/lib/filename-validator.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line no-control-regex -- include control characters
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1f]/;
+
+export interface FilenameValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+export function validateFilename(filename: string): FilenameValidationResult {
+  if (!filename || filename.trim().length === 0) {
+    return {
+      isValid: false,
+      error: "Filename is empty",
+    };
+  }
+
+  if (INVALID_FILENAME_CHARS.test(filename)) {
+    return {
+      isValid: false,
+      error:
+        'Filename contains invalid characters: < > : " / \\ | ? * and control characters',
+    };
+  }
+
+  if (
+    filename.startsWith(".") ||
+    filename.endsWith(".") ||
+    filename.startsWith(" ") ||
+    filename.endsWith(" ")
+  ) {
+    return {
+      isValid: false,
+      error: "Filename cannot start or end with a dot or space",
+    };
+  }
+
+  return {
+    isValid: true,
+  };
+}


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

`new (newArticles)` コマンドでファイル名のバリデーションを追加しました。  
また、バリデーションエラー時にエラーメッセージを出力するようにしています。

## How

- `src/commands/newArticles.ts` にて、`validateFilename` を利用してファイル名のバリデーションを実施
- バリデーションに失敗した場合は、エラーメッセージを `console.error` で出力し、処理をスキップ

## Why

不正なファイル名によるエラーや予期しない挙動を防ぐため、。

## Refs