### PR TITLE
Keep posting campaign when frontmatter has no campaign keys

### DIFF
--- a/src/lib/check-frontmatter-type.test.ts
+++ b/src/lib/check-frontmatter-type.test.ts
@@ -143,6 +143,17 @@ describe("checkFrontmatterType", () => {
       });
     });
 
+    describe("when postingCampaignUuid is undefined", () => {
+      const errorMessages = checkFrontmatterType({
+        ...frontMatter,
+        postingCampaignUuid: undefined,
+      });
+
+      it("returns no errors", () => {
+        expect(errorMessages).toEqual([]);
+      });
+    });
+
     describe("when postingCampaignUuid is string", () => {
       const errorMessages = checkFrontmatterType({
         ...frontMatter,
@@ -171,6 +182,17 @@ describe("checkFrontmatterType", () => {
       const errorMessages = checkFrontmatterType({
         ...frontMatter,
         agreedPostingCampaignTerm: true,
+      });
+
+      it("returns no errors", () => {
+        expect(errorMessages).toEqual([]);
+      });
+    });
+
+    describe("when agreedPostingCampaignTerm is undefined", () => {
+      const errorMessages = checkFrontmatterType({
+        ...frontMatter,
+        agreedPostingCampaignTerm: undefined,
       });
 
       it("returns no errors", () => {

--- a/src/lib/check-frontmatter-type.ts
+++ b/src/lib/check-frontmatter-type.ts
@@ -6,8 +6,8 @@ interface FrontMatter {
   id: string | null;
   organizationUrlName: string | null;
   slide: boolean;
-  postingCampaignUuid: string | null;
-  agreedPostingCampaignTerm: boolean;
+  postingCampaignUuid: string | null | undefined;
+  agreedPostingCampaignTerm: boolean | undefined;
 }
 
 interface CheckType {
@@ -79,7 +79,9 @@ const checkPostingCampaignUuid: CheckType = {
   getMessage: () => "posting_campaign_uuidは文字列で入力してください",
   isValid: ({ postingCampaignUuid }) => {
     return (
-      postingCampaignUuid === null || typeof postingCampaignUuid === "string"
+      postingCampaignUuid === undefined ||
+      postingCampaignUuid === null ||
+      typeof postingCampaignUuid === "string"
     );
   },
 };
@@ -88,7 +90,10 @@ const checkAgreedPostingCampaignTerm: CheckType = {
   getMessage: () =>
     "agreed_posting_campaign_termの設定はtrue/falseで入力してください",
   isValid: ({ agreedPostingCampaignTerm }) => {
-    return typeof agreedPostingCampaignTerm === "boolean";
+    return (
+      agreedPostingCampaignTerm === undefined ||
+      typeof agreedPostingCampaignTerm === "boolean"
+    );
   },
 };
 

--- a/src/lib/entities/qiita-item.ts
+++ b/src/lib/entities/qiita-item.ts
@@ -16,8 +16,8 @@ export class QiitaItem {
   public readonly itemPath: string;
   public readonly slide: boolean;
   public readonly ignorePublish: boolean;
-  public readonly postingCampaignUuid: string | null;
-  public readonly agreedPostingCampaignTerm: boolean;
+  public readonly postingCampaignUuid: string | null | undefined;
+  public readonly agreedPostingCampaignTerm: boolean | undefined;
 
   constructor({
     id,
@@ -53,8 +53,8 @@ export class QiitaItem {
     itemPath: string;
     slide: boolean;
     ignorePublish: boolean;
-    postingCampaignUuid: string | null;
-    agreedPostingCampaignTerm: boolean;
+    postingCampaignUuid: string | null | undefined;
+    agreedPostingCampaignTerm: boolean | undefined;
   }) {
     this.id = id;
     this.title = title;

--- a/src/lib/file-system-repo.test.ts
+++ b/src/lib/file-system-repo.test.ts
@@ -140,6 +140,95 @@ tags: []
         });
       });
     });
+
+    describe("when posting campaign keys are absent in frontmatter", () => {
+      it("keeps them undefined", () => {
+        const instance = new FileSystemRepo({ dataRootDir: "data_root_dir" });
+        const basename = "abc";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValue(`---
+id: this_is_id
+tags: []
+---`);
+
+        return instance.loadItemByBasename(basename).then((item) => {
+          expect(item?.postingCampaignUuid).toBeUndefined();
+          expect(item?.agreedPostingCampaignTerm).toBeUndefined();
+        });
+      });
+
+      it("does not detect modification against remote data with default values", () => {
+        const instance = new FileSystemRepo({ dataRootDir: "data_root_dir" });
+        const basename = "abc";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValueOnce(`---
+title: title
+tags: []
+private: false
+id: this_is_id
+slide: false
+---
+body`);
+        mockFs.readFile.mockResolvedValueOnce(`---
+title: title
+tags: []
+private: false
+id: this_is_id
+slide: false
+posting_campaign_uuid: null
+agreed_posting_campaign_term: false
+---
+body`);
+
+        return instance.loadItemByBasename(basename).then((item) => {
+          expect(item?.modified).toBe(false);
+        });
+      });
+    });
+
+    describe("when posting campaign keys are explicitly set in frontmatter", () => {
+      it("returns the explicit values", () => {
+        const instance = new FileSystemRepo({ dataRootDir: "data_root_dir" });
+        const basename = "abc";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValue(`---
+id: this_is_id
+tags: []
+posting_campaign_uuid: abcde12345fghij67890
+agreed_posting_campaign_term: true
+---`);
+
+        return instance.loadItemByBasename(basename).then((item) => {
+          expect(item?.postingCampaignUuid).toBe("abcde12345fghij67890");
+          expect(item?.agreedPostingCampaignTerm).toBe(true);
+        });
+      });
+
+      it("returns null for an explicit null", () => {
+        const instance = new FileSystemRepo({ dataRootDir: "data_root_dir" });
+        const basename = "abc";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValue(`---
+id: this_is_id
+tags: []
+posting_campaign_uuid: null
+agreed_posting_campaign_term: false
+---`);
+
+        return instance.loadItemByBasename(basename).then((item) => {
+          expect(item?.postingCampaignUuid).toBeNull();
+          expect(item?.agreedPostingCampaignTerm).toBe(false);
+        });
+      });
+    });
   });
 
   describe("loadItems", () => {

--- a/src/lib/file-system-repo.ts
+++ b/src/lib/file-system-repo.ts
@@ -15,8 +15,8 @@ class FileContent {
   public readonly rawBody: string;
   public readonly slide: boolean;
   public readonly ignorePublish: boolean;
-  public readonly postingCampaignUuid: string | null;
-  public readonly agreedPostingCampaignTerm: boolean;
+  public readonly postingCampaignUuid: string | null | undefined;
+  public readonly agreedPostingCampaignTerm: boolean | undefined;
 
   constructor({
     title,
@@ -40,8 +40,8 @@ class FileContent {
     rawBody: string;
     slide: boolean;
     ignorePublish: boolean;
-    postingCampaignUuid: string | null;
-    agreedPostingCampaignTerm: boolean;
+    postingCampaignUuid: string | null | undefined;
+    agreedPostingCampaignTerm: boolean | undefined;
   }) {
     this.title = title;
     this.tags = tags;
@@ -68,8 +68,8 @@ class FileContent {
       organizationUrlName: data.organization_url_name,
       slide: data.slide,
       ignorePublish: data.ignorePublish ?? false,
-      postingCampaignUuid: data.posting_campaign_uuid ?? null,
-      agreedPostingCampaignTerm: data.agreed_posting_campaign_term ?? false,
+      postingCampaignUuid: data.posting_campaign_uuid,
+      agreedPostingCampaignTerm: data.agreed_posting_campaign_term,
     });
   }
 
@@ -138,8 +138,12 @@ class FileContent {
       organization_url_name: this.organizationUrlName,
       slide: this.slide,
       ignorePublish: this.ignorePublish,
-      posting_campaign_uuid: this.postingCampaignUuid,
-      agreed_posting_campaign_term: this.agreedPostingCampaignTerm,
+      ...(this.postingCampaignUuid !== undefined && {
+        posting_campaign_uuid: this.postingCampaignUuid,
+      }),
+      ...(this.agreedPostingCampaignTerm !== undefined && {
+        agreed_posting_campaign_term: this.agreedPostingCampaignTerm,
+      }),
     });
   }
 
@@ -161,8 +165,10 @@ class FileContent {
       this.rawBody === aFileContent.rawBody &&
       this.slide === aFileContent.slide &&
       this.ignorePublish === aFileContent.ignorePublish &&
-      this.postingCampaignUuid === aFileContent.postingCampaignUuid &&
-      this.agreedPostingCampaignTerm === aFileContent.agreedPostingCampaignTerm
+      (this.postingCampaignUuid ?? null) ===
+        (aFileContent.postingCampaignUuid ?? null) &&
+      (this.agreedPostingCampaignTerm ?? false) ===
+        (aFileContent.agreedPostingCampaignTerm ?? false)
     );
   }
 

--- a/src/lib/validators/item-validator.ts
+++ b/src/lib/validators/item-validator.ts
@@ -4,8 +4,8 @@ interface Item {
   tags: string[];
   secret: boolean;
   organizationUrlName: string | null;
-  postingCampaignUuid: string | null;
-  agreedPostingCampaignTerm: boolean;
+  postingCampaignUuid: string | null | undefined;
+  agreedPostingCampaignTerm: boolean | undefined;
 }
 
 interface Validator {

--- a/src/qiita-api/index.ts
+++ b/src/qiita-api/index.ts
@@ -227,8 +227,8 @@ export class QiitaApi {
     isPrivate: boolean;
     organizationUrlName: string | null;
     slide: boolean;
-    postingCampaignUuid: string | null;
-    agreedPostingCampaignTerm: boolean;
+    postingCampaignUuid: string | null | undefined;
+    agreedPostingCampaignTerm: boolean | undefined;
   }) {
     const data = JSON.stringify({
       body: rawBody,
@@ -271,8 +271,8 @@ export class QiitaApi {
     isPrivate: boolean;
     organizationUrlName: string | null;
     slide: boolean;
-    postingCampaignUuid: string | null;
-    agreedPostingCampaignTerm: boolean;
+    postingCampaignUuid: string | null | undefined;
+    agreedPostingCampaignTerm: boolean | undefined;
   }) {
     const data = JSON.stringify({
       body: rawBody,

--- a/src/server/api/items.ts
+++ b/src/server/api/items.ts
@@ -100,7 +100,7 @@ const itemsShow = async (req: Express.Request, res: Express.Response) => {
     ? {
         title: campaign.title,
         link_url: campaign.link_url,
-        agreed: item.agreedPostingCampaignTerm,
+        agreed: item.agreedPostingCampaignTerm ?? false,
       }
     : null;
 


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What
- frontmatter に posting_campaign_uuid キーがない記事ファイルを publish しても、記事投稿キャンペーンの紐付けが解除されないようにした

## How
- frontmatter のキャンペーンキーを3通りに区別するようにした
    - キーなし: キャンペーンの紐付けを変更しない（APIリクエストからキーを省略する）
    - posting_campaign_uuid: null: 紐付けを解除する
    - UUIDを指定: キャンペーンに紐付ける
- キーがないファイルはキャンペーン項目を差分判定（equals）の対象から除外し、frontmatterに該当の項目がない既存ファイルが一律「変更あり」扱いにならないようにした

## Why
- キーがない場合を null に変換してAPIに送信しており、APIは null を「紐付け解除」と解釈するため、v1.9.0 より前から管理しているファイルの publish でキャンペーンが外れてしまっていた

## Refs
