### PR TITLE
Release v1.10.0

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -22,7 +22,7 @@ runs:
       with:
         node-version: "22.23.1"
     - name: Install qiita-cli
-      run: npm install -g @qiita/qiita-cli@v1.9.1
+      run: npm install -g @qiita/qiita-cli@v1.10.0
       shell: bash
     - name: Publish articles
       run: qiita publish --all --root ${{ inputs.root }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiita/qiita-cli",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Qiita CLI is a tool that allows you to write, preview and publish articles on Qiita from local environment.",
   "keywords": [
     "Qiita"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

Qiita CLI v1.10.0をリリースする。

変更点は以下。

- https://github.com/increments/qiita-cli/pull/398
  - フロントマターに書いたタグの順番で投稿できるようにする
- https://github.com/increments/qiita-cli/pull/389
  - Node.js v20系のサポートを終了

差分: https://github.com/increments/qiita-cli/compare/v1.9.1...b7669e07cde5172dfbfc9de3157610f75c57164a

## How

## Why

## Refs
