### PR TITLE
Bump actions/checkout to v7 in generated publish workflow

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: increments/qiita-cli/actions/publish@v1


### PR DESCRIPTION
## What
qiita init が生成する GitHub Actions ワークフローで、Node.js 20 非推奨の警告が出ないようにした

## How
publish.yml テンプレート内の actions/checkout@v4 を @v7 に変更。
このリポジトリ自身の CI (test.yml, publish-package.yml) では既に actions/checkout@v7.0.1 を使っているため、それに合わせた。

## Why
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ により、GitHub は Node.js 20 を非推奨化し、Node 20 をターゲットとするアクションを Node 24 上で強制実行するようになった(警告が出る)。actions/checkout@v4 は Node 20 ランタイムで動作するアクションのため、この警告の対象になっていた。
qiita init はこのワークフローをユーザーのリポジトリに生成するため、qiita-cli で記事を公開しているユーザーの CI 上でこの警告が発生していた。

## Refs
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
