### PR TITLE
Remove derived state from QiitaMarkdownHtmlBody

### DIFF
--- a/src/client/components/QiitaMarkdownHtmlBody.tsx
+++ b/src/client/components/QiitaMarkdownHtmlBody.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useState } from "react";
+import { RefObject, useEffect, useRef } from "react";
 import {
   applyMathJax,
   executeScriptTagsInElement,
@@ -11,20 +11,17 @@ export const QiitaMarkdownHtmlBody = ({
   renderedBody: string;
   bodyRef: RefObject<HTMLDivElement | null>;
 }) => {
-  const [isRendered, setIsRendered] = useState(false);
-
-  // TODO: Refactor to remove useEffect for derived state
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsRendered(true);
-  }, []);
+  // Not idempotent, so run once per body: StrictMode double-invokes effects.
+  const initializedBodyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (isRendered && bodyRef.current) {
-      executeScriptTagsInElement(bodyRef.current);
-      applyMathJax(bodyRef.current);
-    }
-  }, [isRendered, bodyRef, renderedBody]);
+    if (!bodyRef.current) return;
+    if (initializedBodyRef.current === renderedBody) return;
+
+    initializedBodyRef.current = renderedBody;
+    executeScriptTagsInElement(bodyRef.current);
+    applyMathJax(bodyRef.current);
+  }, [bodyRef, renderedBody]);
 
   return (
     <div dangerouslySetInnerHTML={{ __html: renderedBody }} ref={bodyRef}></div>


### PR DESCRIPTION
## What

* `QiitaMarkdownHtmlBody` から `isRendered` state とマウント検知用の `useEffect` を削除した
* あわせて `eslint-disable-next-line react-hooks/set-state-in-effect` と TODO コメントを削除した

## How

* マウント時に `setIsRendered(true)` するだけの `useEffect` を削除し、埋め込み script 実行 / MathJax 適用のエフェクトを `[bodyRef, renderedBody]` 依存で直接走らせるようにした。
* `bodyRef` は props 経由で渡ってくる関係で ESLint が stable と判定できないため、依存配列には残している。

## Why

`eslint-plugin-react-hooks` を上げた #336 で `react-hooks/set-state-in-effect`の警告が出て、`eslint-disable` + TODO で暫定対応していた。

`isRendered` はマウント済みかを表すだけの派生 state で、effect は commit後に走る以上、最初の effect 時点で `bodyRef`は既に紐づいている。ガードとして機能しておらず、埋め込みスクリプトの実行を 1レンダー遅らせていただけ。

不要な state ごと削除し、余分な再レンダーと lint の抑制コメントを解消する。

## 動作確認

`npm run lint` / `npm run build` / `npm test`（96 tests）はいずれも pass。ただし jest は `src/lib` と `src/commands` の Node 側のみで、このコンポーネントを踏むテストは存在しません。

## Refs

* #336
