### PR TITLE
Add experimental local preview support for slides

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
         "src/lib/config.ts",
         "src/lib/file-system-repo.test.ts",
         "src/lib/file-system-repo.ts",
+        "src/lib/slide-file-system-repo.test.ts",
         "src/server/api/readme.ts",
       ],
     },

--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { apiItemsUpdatePath, itemsShowPath } from "../../lib/qiita-cli-url";
 import { breakpoint, pointerFine } from "../lib/mixins";
 import { Colors, Typography, Weight, getSpace } from "../lib/variables";
@@ -110,6 +110,53 @@ export const Header = ({
         <MaterialSymbol>publish</MaterialSymbol>
       </button>
       <Snackbar message={snackbarMessage} setMessage={setSnackbarMessage} />
+    </header>
+  );
+};
+
+export const HeaderSlide = ({
+  slidePath,
+  presentPath,
+  handleMobileOpen,
+}: {
+  slidePath: string;
+  presentPath: string;
+  handleMobileOpen: () => void;
+}) => {
+  const { currentWidth } = useWindowSize();
+  const mobileSize = currentWidth <= breakpoint.S;
+
+  return (
+    <header css={headerStyle}>
+      {mobileSize ? (
+        <div css={headerItemStyle}>
+          <button
+            aria-label="メニューを開く"
+            css={headerMenuButtonStyle}
+            onClick={handleMobileOpen}
+          >
+            <MaterialSymbol size={24}>menu</MaterialSymbol>
+          </button>
+          <div css={mobileHeaderCopyButtonStyle}>
+            ファイルパスをコピー
+            <CopyButton text={slidePath} />
+          </div>
+        </div>
+      ) : (
+        <div css={headerItemStyle}>
+          <p>{slidePath}</p>
+          <CopyButton text={slidePath} />
+        </div>
+      )}
+      <Link
+        css={headerButtonStyle}
+        to={presentPath}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {mobileSize ? "プレゼンモード" : "プレゼンテーションモードで開く"}
+        <MaterialSymbol>slideshow</MaterialSymbol>
+      </Link>
     </header>
   );
 };

--- a/src/client/components/MarpSlidePresenter.tsx
+++ b/src/client/components/MarpSlidePresenter.tsx
@@ -1,0 +1,126 @@
+import { css } from "@emotion/react";
+import {
+  MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+import { Colors, Typography, getSpace } from "../lib/variables";
+import { MarpSlideShadowContent } from "./MarpSlideShadowContent";
+
+const LEFT_KEY = 37;
+const RIGHT_KEY = 39;
+
+interface SlidePage {
+  html: string;
+  speaker_note: string[];
+}
+
+interface Props {
+  pages: SlidePage[];
+  slideCss: string;
+  title?: string;
+}
+
+// `slideCss`, not `css`: the Emotion JSX pragma (jsxImportSource) intercepts
+// any prop literally named `css` on every element, including custom components.
+export const MarpSlidePresenter = ({ pages, slideCss, title }: Props) => {
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+  const totalPage = pages.length;
+
+  const next = useCallback(() => {
+    setCurrentPageIndex((index) => Math.min(index + 1, totalPage - 1));
+  }, [totalPage]);
+  const prev = useCallback(() => {
+    setCurrentPageIndex((index) => Math.max(index - 1, 0));
+  }, []);
+
+  useEffect(() => {
+    const handleGlobalKeyDown = (event: KeyboardEvent) => {
+      if (event.keyCode === LEFT_KEY) {
+        prev();
+      } else if (event.keyCode === RIGHT_KEY) {
+        next();
+      }
+    };
+
+    window.addEventListener("keydown", handleGlobalKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleGlobalKeyDown);
+    };
+  }, [next, prev]);
+
+  const handleClickScreen = useCallback<
+    (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void
+  >(
+    (event) => {
+      const clickedElement = event.nativeEvent.composedPath()[0] as HTMLElement;
+
+      if (clickedElement.tagName === "IMG" || clickedElement.tagName === "A") {
+        return;
+      }
+
+      const rect = event.currentTarget.getBoundingClientRect();
+
+      if (event.clientX - rect.left > rect.width / 2) {
+        next();
+      } else {
+        prev();
+      }
+    },
+    [next, prev],
+  );
+
+  const page: SlidePage | undefined = pages[currentPageIndex];
+
+  return (
+    <div css={containerStyle}>
+      <div css={contentStyle} onClick={handleClickScreen}>
+        <MarpSlideShadowContent slideCss={slideCss} html={page?.html ?? ""} />
+      </div>
+      <div css={footerStyle}>
+        <span css={titleStyle}>{title}</span>
+        {totalPage > 0 && (
+          <span css={pageCounterStyle}>
+            {currentPageIndex + 1} / {totalPage}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+});
+
+const contentStyle = css({
+  cursor: "pointer",
+  flex: 1,
+  overflow: "auto",
+});
+
+const footerStyle = css({
+  alignItems: "center",
+  backgroundColor: Colors.gray0,
+  borderTop: `1px solid ${Colors.divider}`,
+  display: "flex",
+  fontSize: Typography.body2,
+  justifyContent: "space-between",
+  padding: `${getSpace(1)}px ${getSpace(2)}px`,
+});
+
+const titleStyle = css({
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+const pageCounterStyle = css({
+  color: Colors.mediumEmphasis,
+  flexShrink: 0,
+  marginLeft: getSpace(2),
+});

--- a/src/client/components/MarpSlideShadowContent.tsx
+++ b/src/client/components/MarpSlideShadowContent.tsx
@@ -1,0 +1,47 @@
+import { css } from "@emotion/react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface Props {
+  html: string;
+  slideCss: string;
+}
+
+// Marp-generated CSS targets bare element/`:root` selectors, so it must be
+// rendered inside a shadow root to avoid leaking into (or being overridden
+// by) the surrounding app styles.
+// Named `slideCss`, not `css`: the Emotion JSX pragma (jsxImportSource) intercepts
+// any prop literally named `css` on every element, including custom components.
+export const MarpSlideShadowContent = ({ html, slideCss }: Props) => {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+
+  useEffect(() => {
+    if (!hostRef.current) return;
+    setShadowRoot(
+      hostRef.current.shadowRoot ??
+        hostRef.current.attachShadow({ mode: "open" }),
+    );
+  }, []);
+
+  return (
+    <div ref={hostRef} css={hostStyle}>
+      {shadowRoot &&
+        createPortal(
+          <>
+            <style>{slideCss}</style>
+            <div
+              className="marp-slide-container"
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          </>,
+          shadowRoot,
+        )}
+    </div>
+  );
+};
+
+const hostStyle = css({
+  height: "100%",
+  width: "100%",
+});

--- a/src/client/components/MarpSlideViewer/index.tsx
+++ b/src/client/components/MarpSlideViewer/index.tsx
@@ -1,0 +1,61 @@
+import { css } from "@emotion/react";
+import { Colors, Typography, getSpace } from "../../lib/variables";
+import { MarpSlideShadowContent } from "../MarpSlideShadowContent";
+
+interface SlidePage {
+  html: string;
+  speaker_note: string[];
+}
+
+interface Props {
+  pages: SlidePage[];
+  slideCss: string;
+}
+
+// `slideCss`, not `css`: the Emotion JSX pragma (jsxImportSource) intercepts
+// any prop literally named `css` on every element, including custom components.
+export const MarpSlideViewer = ({ pages, slideCss }: Props) => {
+  const totalPage = pages.length;
+
+  return (
+    <div css={listStyle}>
+      {pages.map((page, index) => (
+        <div key={index} css={pageWrapperStyle}>
+          <div css={pageStyle}>
+            <MarpSlideShadowContent slideCss={slideCss} html={page.html} />
+          </div>
+          <span css={pageNumberStyle}>
+            {index + 1} / {totalPage}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const listStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: getSpace(3),
+  width: "100%",
+});
+
+const pageWrapperStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: getSpace(1 / 2),
+  width: "100%",
+});
+
+const pageStyle = css({
+  aspectRatio: "16 / 9",
+  boxShadow: "0 1px 4px rgba(0, 0, 0, 0.2)",
+  overflow: "hidden",
+  width: "100%",
+});
+
+const pageNumberStyle = css({
+  alignSelf: "flex-end",
+  color: Colors.mediumEmphasis,
+  fontSize: Typography.body2,
+});

--- a/src/client/components/Router.tsx
+++ b/src/client/components/Router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from "react-router";
 import { ItemsIndex } from "../pages/items";
 import { ItemsShow } from "../pages/items/show";
+import { SlidesShow } from "../pages/slides/show";
 import { Layout } from "./Layout";
 
 const router = createBrowserRouter([
@@ -15,6 +16,10 @@ const router = createBrowserRouter([
       {
         path: "/items/:id",
         element: <ItemsShow />,
+      },
+      {
+        path: "/slides/:id",
+        element: <SlidesShow />,
       },
     ],
   },

--- a/src/client/components/SidebarContents.tsx
+++ b/src/client/components/SidebarContents.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Link } from "react-router";
 import { itemsIndexPath } from "../../lib/qiita-cli-url";
 import { ItemsIndexViewModel } from "../../lib/view-models/items";
+import { SlidesIndexViewModel } from "../../lib/view-models/slides";
 import { breakpoint, pointerFine, viewport } from "../lib/mixins";
 import {
   Colors,
@@ -16,6 +17,7 @@ import { useHotReloadEffect } from "./HotReloadRoot";
 import { QiitaLogo, QiitaPreviewLogo } from "./Logo";
 import { MaterialSymbol } from "./MaterialSymbol";
 import { SidebarArticles, SortType } from "./SidebarArticles";
+import { SidebarSlides } from "./SidebarSlides";
 import { Tooltip } from "./Tooltip";
 
 interface Props {
@@ -27,6 +29,7 @@ type SortType = (typeof SortType)[keyof typeof SortType];
 
 export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
   const [items, setItems] = useState<ItemsIndexViewModel>();
+  const [slides, setSlides] = useState<SlidesIndexViewModel>();
   const [isOpen, setIsOpen] = useState(
     localStorage.getItem("openSidebarState") === "true",
   );
@@ -39,6 +42,15 @@ export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
     fetch("/api/items").then((result) => {
       result.json().then((data) => {
         setItems(data);
+      });
+    });
+  }, []);
+
+  useHotReloadEffect(() => {
+    fetch("/api/slides").then((result) => {
+      if (!result.ok) return;
+      result.json().then((data) => {
+        setSlides(data);
       });
     });
   }, []);
@@ -56,6 +68,20 @@ export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
         const params = new URLSearchParams(location.search);
         params.set("basename", data.basename);
         const url = new URL("/items/show", location.href);
+        url.search = params.toString();
+        location.href = url.toString();
+      });
+    });
+  };
+
+  const handleNewSlide = () => {
+    fetch("/api/slides", {
+      method: "POST",
+    }).then((response) => {
+      response.json().then((data) => {
+        const params = new URLSearchParams(location.search);
+        params.set("basename", data.basename);
+        const url = new URL("/slides/show", location.href);
         url.search = params.toString();
         location.href = url.toString();
       });
@@ -120,6 +146,16 @@ export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
               新規記事作成
             </button>
           </li>
+          {slides && (
+            <li>
+              <button css={articlesListItemStyle} onClick={handleNewSlide}>
+                <MaterialSymbol css={{ color: Colors.disabled }}>
+                  add
+                </MaterialSymbol>
+                新規スライド作成
+              </button>
+            </li>
+          )}
         </ul>
         <div css={articlesStyle}>
           <div css={articlesHeaderStyle}>
@@ -164,6 +200,25 @@ export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
             )}
           </div>
         </div>
+        {slides && (
+          <div css={articlesStyle}>
+            <div css={articlesHeaderStyle}>
+              <h1 css={articlesHeaderTitleStyle}>Slides</h1>
+            </div>
+            <div>
+              <SidebarSlides
+                slides={slides.draft}
+                sortType={sortType}
+                slideState={"Draft"}
+              />
+              <SidebarSlides
+                slides={slides.published}
+                sortType={sortType}
+                slideState={"Published"}
+              />
+            </div>
+          </div>
+        )}
       </nav>
       <footer css={articleFooterStyle}>
         <a
@@ -305,6 +360,16 @@ export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
               新規記事作成
             </button>
           </li>
+          {slides && (
+            <li>
+              <button css={articlesListItemStyle} onClick={handleNewSlide}>
+                <MaterialSymbol css={{ color: Colors.disabled }}>
+                  add
+                </MaterialSymbol>
+                新規スライド作成
+              </button>
+            </li>
+          )}
         </ul>
         <div css={articlesStyle}>
           <div css={articlesHeaderStyle}>
@@ -349,6 +414,25 @@ export const SidebarContents = ({ isStateOpen, handleMobileClose }: Props) => {
             )}
           </div>
         </div>
+        {slides && (
+          <div css={articlesStyle}>
+            <div css={articlesHeaderStyle}>
+              <h1 css={articlesHeaderTitleStyle}>Slides</h1>
+            </div>
+            <div>
+              <SidebarSlides
+                slides={slides.draft}
+                sortType={sortType}
+                slideState={"Draft"}
+              />
+              <SidebarSlides
+                slides={slides.published}
+                sortType={sortType}
+                slideState={"Published"}
+              />
+            </div>
+          </div>
+        )}
       </nav>
       <footer css={articleFooterStyle}>
         <a

--- a/src/client/components/SidebarSlides.tsx
+++ b/src/client/components/SidebarSlides.tsx
@@ -1,0 +1,153 @@
+import { css } from "@emotion/react";
+import { useState, useEffect } from "react";
+import { MaterialSymbol } from "./MaterialSymbol";
+import { Link } from "react-router";
+import { pointerFine } from "../lib/mixins";
+import {
+  Colors,
+  getSpace,
+  LineHeight,
+  Typography,
+  Weight,
+} from "../lib/variables";
+import { SlideViewModel } from "../../lib/view-models/slides";
+import { SortType } from "./SidebarArticles";
+
+interface Props {
+  slides: SlideViewModel[];
+  sortType: (typeof SortType)[keyof typeof SortType];
+  slideState: "Draft" | "Published";
+}
+
+const SlideState = {
+  Draft: "未投稿",
+  Published: "投稿済み",
+};
+const StorageName = {
+  Draft: "openDraftSlidesState",
+  Published: "openPublishedSlidesState",
+};
+
+export const SidebarSlides = ({ slides, sortType, slideState }: Props) => {
+  const compare = {
+    [SortType.ByUpdatedAt]: (a: SlideViewModel, b: SlideViewModel) => {
+      if (!a.updated_at) return -1;
+      if (!b.updated_at) return 1;
+      return b.updated_at.localeCompare(a.updated_at);
+    },
+    [SortType.Alphabetically]: (a: SlideViewModel, b: SlideViewModel) => {
+      return a.title.localeCompare(b.title);
+    },
+  };
+
+  const [isDetailsOpen, setIsDetailsOpen] = useState(
+    localStorage.getItem(StorageName[slideState]) === "true",
+  );
+
+  const toggleAccordion = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    setIsDetailsOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    localStorage.setItem(StorageName[slideState], isDetailsOpen.toString());
+  }, [isDetailsOpen, slideState]);
+
+  return (
+    <details css={slideDetailsStyle} open={isDetailsOpen}>
+      <summary css={slideSummaryStyle} onClick={toggleAccordion}>
+        {SlideState[slideState]}
+        <span css={slideSectionTitleCountStyle}>{slides.length}</span>
+      </summary>
+      <ul css={slideDetailsListStyle}>
+        {[...slides].sort(compare[sortType]).map((slide) => (
+          <li key={slide.slides_show_path}>
+            <Link css={slidesListItemStyle} to={slide.slides_show_path}>
+              <MaterialSymbol>slideshow</MaterialSymbol>
+              <span css={slideListItemInnerStyle}>{slide.title}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+};
+
+const slideDetailsStyle = css({
+  "& > summary::before": {
+    fontFamily: "Material Symbols Outlined",
+    content: "'expand_less'",
+  },
+
+  "&[open] > summary::before": {
+    content: "'expand_more'",
+  },
+});
+
+const slideDetailsListStyle = css({
+  listStyle: "none",
+  margin: 0,
+  paddingLeft: getSpace(1),
+});
+
+const slideSummaryStyle = css({
+  alignItems: "center",
+  backgroundColor: "transparent",
+  color: Colors.mediumEmphasis,
+  cursor: "pointer",
+  display: "flex",
+  fontWeight: Weight.bold,
+  fontSize: Typography.body2,
+  gap: getSpace(1),
+  padding: `${getSpace(1 / 2)}px ${getSpace(2)}px`,
+  width: "100%",
+  boxSizing: "border-box",
+
+  ...pointerFine({
+    "&:hover": {
+      backgroundColor: Colors.gray10,
+      cursor: "pointer",
+      textDecoration: "none",
+    },
+  }),
+
+  "&::-webkit-details-marker": {
+    display: "none",
+  },
+});
+
+const slideSectionTitleCountStyle = css({
+  backgroundColor: Colors.gray20,
+  borderRadius: 4,
+  fontSize: Typography.body3,
+  lineHeight: LineHeight.bodyDense,
+  padding: `0 ${getSpace(1 / 2)}px`,
+});
+
+const slidesListItemStyle = css({
+  alignItems: "center",
+  backgroundColor: "transparent",
+  color: Colors.mediumEmphasis,
+  display: "flex",
+  fontSize: Typography.body2,
+  gap: getSpace(1),
+  lineHeight: LineHeight.bodyDense,
+  padding: `${getSpace(3 / 4)}px ${getSpace(5 / 2)}px ${getSpace(3 / 4)}px ${getSpace(
+    3,
+  )}px`,
+  whiteSpace: "nowrap",
+  textOverflow: "ellipsis",
+
+  ...pointerFine({
+    "&:hover": {
+      backgroundColor: Colors.gray10,
+      textDecoration: "none",
+    },
+  }),
+});
+
+const slideListItemInnerStyle = css({
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});

--- a/src/client/components/SlideInfo.tsx
+++ b/src/client/components/SlideInfo.tsx
@@ -1,0 +1,155 @@
+import { css } from "@emotion/react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import {
+  Colors,
+  LineHeight,
+  Typography,
+  Weight,
+  getSpace,
+} from "../lib/variables";
+import { MaterialSymbol } from "./MaterialSymbol";
+
+interface Props {
+  title: string;
+  theme: string | null;
+  published: boolean;
+  pageCount: number;
+  errorMessages: string[];
+}
+
+export const SlideInfo = ({
+  title,
+  theme,
+  published,
+  pageCount,
+  errorMessages,
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(
+    localStorage.getItem("openSlideInfoState") === "true" ? true : false,
+  );
+
+  const toggleAccordion = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    setIsOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    localStorage.setItem("openSlideInfoState", JSON.stringify(isOpen));
+  }, [isOpen]);
+
+  return (
+    <>
+      <details css={infoStyle} open={isOpen}>
+        <summary css={infoSummaryStyle} onClick={toggleAccordion}>
+          スライド情報
+        </summary>
+        <InfoItem title="タイトル">{title}</InfoItem>
+        <InfoItem title="テーマ">{theme ?? "未設定"}</InfoItem>
+        <InfoItem title="スライドの状態">
+          {published ? "投稿済み" : "未投稿"}
+        </InfoItem>
+        <InfoItem title="ページ数">{pageCount}</InfoItem>
+      </details>
+      {errorMessages.length > 0 && (
+        <div css={errorContentsStyle}>
+          {errorMessages.map((errorMessage, index) => (
+            <p key={`error-message-${index}`} css={errorStyle}>
+              <MaterialSymbol fill={true} css={exclamationIconStyle}>
+                error
+              </MaterialSymbol>
+              {errorMessage}
+            </p>
+          ))}
+        </div>
+      )}
+    </>
+  );
+};
+
+const infoStyle = css({
+  backgroundColor: Colors.gray10,
+  borderRadius: 8,
+  display: "flex",
+  flexDirection: "column",
+  padding: `${getSpace(3 / 2)}px ${getSpace(2)}px`,
+  width: "100%",
+
+  "& > summary::after": {
+    fontFamily: "Material Symbols Outlined",
+    content: "'expand_less'",
+  },
+
+  "&[open] > summary::after": {
+    content: "'expand_more'",
+  },
+});
+
+const infoSummaryStyle = css({
+  alignItems: "center",
+  display: "flex",
+  cursor: "pointer",
+
+  "&::-webkit-details-marker": {
+    display: "none",
+  },
+});
+
+interface InfoItemProps {
+  children?: ReactNode;
+  title: string;
+}
+
+const InfoItem = ({ children, title }: InfoItemProps) => {
+  return (
+    <div css={infoListStyle}>
+      <p css={titleStyle}>{title}</p>
+      <p css={bodyStyle}>{children}</p>
+    </div>
+  );
+};
+
+const infoListStyle = css({
+  display: "grid",
+  gridTemplateColumns: "100px minmax(0, 1fr)",
+  gap: getSpace(3 / 2),
+
+  "& + &": {
+    marginTop: getSpace(1 / 2),
+  },
+});
+
+const titleStyle = css({
+  color: Colors.disabled,
+  fontSize: Typography.body2,
+  fontWeight: Weight.bold,
+});
+
+const bodyStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: ` 0 ${getSpace(1 / 2)}px`,
+  fontSize: Typography.body2,
+  lineHeight: LineHeight.bodyDense,
+  wordBreak: "break-word",
+});
+
+const exclamationIconStyle = css({
+  color: Colors.yellow60,
+});
+
+const errorContentsStyle = css({
+  marginTop: getSpace(3),
+});
+
+const errorStyle = css({
+  alignItems: "center",
+  display: "flex",
+  fontSize: Typography.body2,
+  lineHeight: LineHeight.bodyDense,
+  gap: getSpace(1 / 2),
+
+  "& + &": {
+    marginTop: getSpace(3 / 2),
+  },
+});

--- a/src/client/lib/embed-init-scripts.test.ts
+++ b/src/client/lib/embed-init-scripts.test.ts
@@ -1,0 +1,56 @@
+interface GlobalWithWindow {
+  window: { qiitaEmbedInit?: unknown } | undefined;
+}
+
+const globalWithWindow = global as unknown as GlobalWithWindow;
+
+describe("embed-init-scripts", () => {
+  const originalWindow = globalWithWindow.window;
+
+  afterEach(() => {
+    globalWithWindow.window = originalWindow;
+  });
+
+  const loadModule = (): typeof import("./embed-init-scripts") => {
+    let mod!: typeof import("./embed-init-scripts");
+    jest.isolateModules(() => {
+      mod = require("./embed-init-scripts");
+    });
+    return mod;
+  };
+
+  describe("when window.qiitaEmbedInit is undefined", () => {
+    beforeEach(() => {
+      globalWithWindow.window = {};
+    });
+
+    it("does not throw while loading the module", () => {
+      expect(() => loadModule()).not.toThrow();
+    });
+
+    it("exposes undefined utilities", () => {
+      const { applyMathJax, executeScriptTagsInElement } = loadModule();
+
+      expect(applyMathJax).toBeUndefined();
+      expect(executeScriptTagsInElement).toBeUndefined();
+    });
+  });
+
+  describe("when window.qiitaEmbedInit is defined", () => {
+    const applyMathJax = jest.fn();
+    const executeScriptTagsInElement = jest.fn();
+
+    beforeEach(() => {
+      globalWithWindow.window = {
+        qiitaEmbedInit: { applyMathJax, executeScriptTagsInElement },
+      };
+    });
+
+    it("exposes the underlying utilities", () => {
+      const mod = loadModule();
+
+      expect(mod.applyMathJax).toBe(applyMathJax);
+      expect(mod.executeScriptTagsInElement).toBe(executeScriptTagsInElement);
+    });
+  });
+});

--- a/src/client/lib/embed-init-scripts.ts
+++ b/src/client/lib/embed-init-scripts.ts
@@ -1,3 +1,3 @@
-const qiitaEmbedInit = (window as any).qiitaEmbedInit;
+const qiitaEmbedInit = (window as any).qiitaEmbedInit ?? {};
 
 export const { applyMathJax, executeScriptTagsInElement } = qiitaEmbedInit;

--- a/src/client/pages/slides/show.tsx
+++ b/src/client/pages/slides/show.tsx
@@ -1,0 +1,202 @@
+import { css } from "@emotion/react";
+import { useState } from "react";
+import { useLocation, useParams, useSearchParams } from "react-router";
+import { apiSlidesShowPath } from "../../../lib/qiita-cli-url";
+import type { SlidesShowViewModel } from "../../../lib/view-models/slides";
+import { HeaderSlide } from "../../components/Header";
+import { useHotReloadEffect } from "../../components/HotReloadRoot";
+import { MarpSlidePresenter } from "../../components/MarpSlidePresenter";
+import { MarpSlideViewer } from "../../components/MarpSlideViewer";
+import { MaterialSymbol } from "../../components/MaterialSymbol";
+import { SidebarContents } from "../../components/SidebarContents";
+import { SlideInfo } from "../../components/SlideInfo";
+import {
+  Colors,
+  LineHeight,
+  Typography,
+  Weight,
+  getSpace,
+} from "../../lib/variables";
+import { Contents } from "../../templates/Contents";
+import { Main } from "../../templates/Main";
+import { Sidebar } from "../../templates/Sidebar";
+
+export const SlidesShow = () => {
+  const { id } = useParams();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const basename = searchParams.get("basename");
+  const isPresentationMode = searchParams.get("present") === "1";
+
+  const [slide, setSlide] = useState<SlidesShowViewModel | null>(null);
+  const [error, setError] = useState<null | string>(null);
+  const [errorFrontmatterMessages, setErrorFrontmatterMessages] = useState<
+    null | string[]
+  >(null);
+  const [isStateOpen, setIsStateOpen] = useState(false);
+
+  const handleMobileOpen = () => {
+    setIsStateOpen(true);
+  };
+
+  const handleMobileClose = () => {
+    setIsStateOpen(false);
+  };
+
+  useHotReloadEffect(() => {
+    if (!id) return;
+    const queryParams = basename ? { basename: basename } : undefined;
+    const fetchURL = apiSlidesShowPath(id, queryParams);
+
+    fetch(fetchURL).then((response) => {
+      if (!response.ok) {
+        if (response.status === 404) {
+          setError("ファイルが見つかりません");
+          setSlide(null);
+        } else {
+          response.json().then((data) => {
+            setError(null);
+            setErrorFrontmatterMessages(data.errorMessages);
+            setSlide(null);
+          });
+        }
+      } else {
+        response.json().then((data) => {
+          setSlide(data);
+        });
+      }
+    });
+  }, [id, basename]);
+
+  if (isPresentationMode) {
+    return slide ? (
+      <div css={presentationScreenStyle}>
+        <MarpSlidePresenter
+          pages={slide.pages}
+          slideCss={slide.css}
+          title={slide.title}
+        />
+      </div>
+    ) : (
+      <div css={messageContainerStyle}>
+        {error && <p css={errorMessageStyle}>{error}</p>}
+      </div>
+    );
+  }
+
+  const presentSearchParams = new URLSearchParams(searchParams);
+  presentSearchParams.set("present", "1");
+  const presentPath = `${location.pathname}?${presentSearchParams.toString()}`;
+
+  return (
+    <Main>
+      <Sidebar>
+        <SidebarContents
+          isStateOpen={isStateOpen}
+          handleMobileClose={handleMobileClose}
+        />
+      </Sidebar>
+
+      <Contents>
+        {slide ? (
+          <>
+            <HeaderSlide
+              handleMobileOpen={handleMobileOpen}
+              slidePath={slide.slide_path}
+              presentPath={presentPath}
+            />
+            <div css={contentsWrapperStyle}>
+              <div css={contentsContainerStyle}>
+                <SlideInfo
+                  title={slide.title}
+                  theme={slide.theme}
+                  published={slide.published}
+                  pageCount={slide.pages.length}
+                  errorMessages={slide.error_messages}
+                />
+                <div css={viewerWrapStyle}>
+                  <MarpSlideViewer pages={slide.pages} slideCss={slide.css} />
+                </div>
+              </div>
+            </div>
+          </>
+        ) : error ? (
+          <p css={errorMessageStyle}>{error}</p>
+        ) : errorFrontmatterMessages && errorFrontmatterMessages.length > 0 ? (
+          <div css={errorContentsStyle}>
+            <p css={errorTitleStyle}>
+              スライドの設定の入力内容に誤りがあるため、プレビューが表示できません
+            </p>
+            {errorFrontmatterMessages.map((errorMessage, index) => (
+              <p key={`error-message-${index}`} css={errorStyle}>
+                <MaterialSymbol fill={true} css={exclamationIconStyle}>
+                  error
+                </MaterialSymbol>
+                <div>{errorMessage}</div>
+              </p>
+            ))}
+          </div>
+        ) : null}
+      </Contents>
+    </Main>
+  );
+};
+
+const contentsWrapperStyle = css({
+  margin: `${getSpace(2)}px ${getSpace(2)}px 0`,
+});
+
+const contentsContainerStyle = css({
+  backgroundColor: Colors.gray0,
+  borderRadius: 8,
+  maxWidth: 820,
+  margin: "0 auto",
+  padding: getSpace(3),
+});
+
+const viewerWrapStyle = css({
+  marginTop: getSpace(3),
+});
+
+const presentationScreenStyle = css({
+  height: "100vh",
+});
+
+const messageContainerStyle = css({
+  alignItems: "center",
+  display: "flex",
+  height: "100vh",
+  justifyContent: "center",
+});
+
+const errorMessageStyle = css({
+  fontSize: Typography.subhead2,
+  padding: getSpace(2),
+  textAlign: "center",
+});
+
+const errorContentsStyle = css({
+  backgroundColor: Colors.red10,
+  borderRadius: 8,
+  fontSize: Typography.body2,
+  lineHeight: LineHeight.bodyDense,
+  margin: `${getSpace(3)}px auto 0`,
+  width: "fit-content",
+  maxWidth: "calc(100% - 32px)",
+  padding: `${getSpace(2)}px ${getSpace(3)}px`,
+});
+
+const exclamationIconStyle = css({
+  color: Colors.red60,
+  marginRight: getSpace(1 / 2),
+});
+
+const errorTitleStyle = css({
+  fontWeight: Weight.bold,
+});
+
+const errorStyle = css({
+  alignItems: "center",
+  display: "flex",
+  marginTop: getSpace(3 / 2),
+});

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -5,6 +5,9 @@ COMMAND:
   init                    記事をGitHubで管理するための初期設定
   login                   Qiita APIの認証認可
   new [<basename>] ...    新しい記事を追加
+  new --slide [<basename>] ...
+                          新しいスライドを追加(実験的機能。qiita.config.jsonで
+                          experimentalSlideFeatureEnabledをtrueにすると使用可能)
   preview                 コンテンツをブラウザでプレビュー
   publish <basename> ...  記事を投稿、更新
   publish --all           全ての記事を投稿、更新

--- a/src/commands/newArticles.test.ts
+++ b/src/commands/newArticles.test.ts
@@ -1,0 +1,119 @@
+import type { FileSystemRepo } from "../lib/file-system-repo";
+import type { SlideFileSystemRepo } from "../lib/slide-file-system-repo";
+import { getFileSystemRepo } from "../lib/get-file-system-repo";
+import { getSlideFileSystemRepo } from "../lib/get-slide-file-system-repo";
+import { config } from "../lib/config";
+import { newArticles } from "./newArticles";
+
+jest.mock("../lib/get-file-system-repo");
+jest.mock("../lib/get-slide-file-system-repo");
+jest.mock("../lib/config");
+
+const mockGetFileSystemRepo = jest.mocked(getFileSystemRepo);
+const mockGetSlideFileSystemRepo = jest.mocked(getSlideFileSystemRepo);
+const mockConfig = jest.mocked(config);
+
+describe("newArticles", () => {
+  const fileSystemRepo = {
+    createItem: jest.fn(),
+  } as unknown as jest.Mocked<FileSystemRepo>;
+
+  const slideFileSystemRepo = {
+    createSlide: jest.fn(),
+  } as unknown as jest.Mocked<SlideFileSystemRepo>;
+
+  class ProcessExitError extends Error {
+    constructor(public readonly code: string | number | null | undefined) {
+      super(`process.exit(${code})`);
+    }
+  }
+
+  let exitSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetFileSystemRepo.mockResolvedValue(fileSystemRepo);
+    mockGetSlideFileSystemRepo.mockResolvedValue(slideFileSystemRepo);
+    fileSystemRepo.createItem.mockResolvedValue("article");
+    slideFileSystemRepo.createSlide.mockResolvedValue("deck");
+
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((code?: string | number | null) => {
+        throw new ProcessExitError(code);
+      });
+    logSpy = jest.spyOn(console, "log").mockImplementation();
+    errorSpy = jest.spyOn(console, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe("--slide", () => {
+    describe("when the experimental slide feature is disabled (default)", () => {
+      beforeEach(() => {
+        mockConfig.getUserConfig.mockResolvedValue({
+          includePrivate: false,
+          host: "localhost",
+          port: 8888,
+          experimentalSlideFeatureEnabled: false,
+        });
+      });
+
+      it("exits with an error and does not create a slide", async () => {
+        await expect(newArticles(["--slide"])).rejects.toThrow(
+          ProcessExitError,
+        );
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("experimentalSlideFeatureEnabled"),
+        );
+        expect(slideFileSystemRepo.createSlide).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the experimental slide feature is enabled", () => {
+      beforeEach(() => {
+        mockConfig.getUserConfig.mockResolvedValue({
+          includePrivate: false,
+          host: "localhost",
+          port: 8888,
+          experimentalSlideFeatureEnabled: true,
+        });
+      });
+
+      it("creates a slide", async () => {
+        await newArticles(["--slide"]);
+
+        expect(slideFileSystemRepo.createSlide).toHaveBeenCalledWith(undefined);
+        expect(logSpy).toHaveBeenCalledWith("created: deck.md");
+        expect(exitSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("without --slide", () => {
+    beforeEach(() => {
+      mockConfig.getUserConfig.mockResolvedValue({
+        includePrivate: false,
+        host: "localhost",
+        port: 8888,
+        experimentalSlideFeatureEnabled: false,
+      });
+    });
+
+    it("creates an article regardless of the experimental slide feature flag", async () => {
+      await newArticles([]);
+
+      expect(fileSystemRepo.createItem).toHaveBeenCalledWith(undefined);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/commands/newArticles.ts
+++ b/src/commands/newArticles.ts
@@ -1,26 +1,59 @@
 import arg from "arg";
+import process from "node:process";
+import { config } from "../lib/config";
 import { getFileSystemRepo } from "../lib/get-file-system-repo";
+import { getSlideFileSystemRepo } from "../lib/get-slide-file-system-repo";
 
-export const newArticles = async (argv: string[]) => {
-  const args = arg({}, { argv });
-
-  const fileSystemRepo = await getFileSystemRepo();
-
-  if (args._.length > 0) {
-    for (const basename of args._) {
-      const createdFileName = await fileSystemRepo.createItem(basename);
-      if (createdFileName) {
-        console.log(`created: ${createdFileName}.md`);
-      } else {
-        console.error(`Error: '${basename}.md' is already exist`);
-      }
-    }
-  } else {
-    const createdFileName = await fileSystemRepo.createItem();
+const createWithBasenames = async (
+  basenames: string[],
+  createItem: (basename?: string) => Promise<string | undefined>,
+) => {
+  if (basenames.length === 0) {
+    const createdFileName = await createItem();
     if (createdFileName) {
       console.log(`created: ${createdFileName}.md`);
     } else {
       console.error("Error: failed to create");
     }
+    return;
+  }
+
+  for (const basename of basenames) {
+    const createdFileName = await createItem(basename);
+    if (createdFileName) {
+      console.log(`created: ${createdFileName}.md`);
+    } else {
+      console.error(`Error: '${basename}.md' is already exist`);
+    }
+  }
+};
+
+export const newArticles = async (argv: string[]) => {
+  const args = arg(
+    {
+      "--slide": Boolean,
+    },
+    { argv },
+  );
+
+  if (args["--slide"]) {
+    const userConfig = await config.getUserConfig();
+    if (!userConfig.experimentalSlideFeatureEnabled) {
+      console.error(
+        'Error: the slide feature is experimental and disabled by default. Set "experimentalSlideFeatureEnabled": true in qiita.config.json to enable it.',
+      );
+      process.exit(1);
+      return;
+    }
+
+    const slideFileSystemRepo = await getSlideFileSystemRepo();
+    await createWithBasenames(args._, (basename) =>
+      slideFileSystemRepo.createSlide(basename),
+    );
+  } else {
+    const fileSystemRepo = await getFileSystemRepo();
+    await createWithBasenames(args._, (basename) =>
+      fileSystemRepo.createItem(basename),
+    );
   }
 };

--- a/src/commands/preview.test.ts
+++ b/src/commands/preview.test.ts
@@ -1,0 +1,94 @@
+import type { FileSystemRepo } from "../lib/file-system-repo";
+import type { SlideFileSystemRepo } from "../lib/slide-file-system-repo";
+import { getFileSystemRepo } from "../lib/get-file-system-repo";
+import { getSlideFileSystemRepo } from "../lib/get-slide-file-system-repo";
+import { getQiitaApiInstance } from "../lib/get-qiita-api-instance";
+import { syncArticlesFromQiita } from "../lib/sync-articles-from-qiita";
+import { config } from "../lib/config";
+import { startLocalChangeWatcher, startServer } from "../server/app";
+import { preview } from "./preview";
+
+jest.mock("../lib/get-file-system-repo");
+jest.mock("../lib/get-slide-file-system-repo");
+jest.mock("../lib/get-qiita-api-instance");
+jest.mock("../lib/sync-articles-from-qiita");
+jest.mock("../lib/config");
+jest.mock("../server/app");
+
+const mockGetFileSystemRepo = jest.mocked(getFileSystemRepo);
+const mockGetSlideFileSystemRepo = jest.mocked(getSlideFileSystemRepo);
+const mockGetQiitaApiInstance = jest.mocked(getQiitaApiInstance);
+const mockSyncArticlesFromQiita = jest.mocked(syncArticlesFromQiita);
+const mockConfig = jest.mocked(config);
+const mockStartServer = jest.mocked(startServer);
+const mockStartLocalChangeWatcher = jest.mocked(startLocalChangeWatcher);
+
+describe("preview", () => {
+  const fileSystemRepo = {
+    getRootPath: jest.fn().mockReturnValue("/data/public"),
+  } as unknown as jest.Mocked<FileSystemRepo>;
+
+  const slideFileSystemRepo = {
+    getRootPath: jest.fn().mockReturnValue("/data/slides"),
+  } as unknown as jest.Mocked<SlideFileSystemRepo>;
+
+  const qiitaApi = {} as ReturnType<typeof getQiitaApiInstance>;
+  const server = { address: () => null } as unknown as ReturnType<
+    typeof startServer
+  > extends Promise<infer T>
+    ? T
+    : never;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetFileSystemRepo.mockResolvedValue(fileSystemRepo);
+    mockGetSlideFileSystemRepo.mockResolvedValue(slideFileSystemRepo);
+    mockGetQiitaApiInstance.mockResolvedValue(qiitaApi);
+    mockSyncArticlesFromQiita.mockResolvedValue();
+    mockStartServer.mockResolvedValue(server);
+    mockStartLocalChangeWatcher.mockImplementation();
+  });
+
+  describe("when the experimental slide feature is disabled (default)", () => {
+    beforeEach(() => {
+      mockConfig.getUserConfig.mockResolvedValue({
+        includePrivate: false,
+        host: "localhost",
+        port: 8888,
+        experimentalSlideFeatureEnabled: false,
+      });
+    });
+
+    it("does not build a slide file system repo and watches only the article root", async () => {
+      await preview();
+
+      expect(mockGetSlideFileSystemRepo).not.toHaveBeenCalled();
+      expect(mockStartLocalChangeWatcher).toHaveBeenCalledWith({
+        server,
+        watchPaths: ["/data/public"],
+      });
+    });
+  });
+
+  describe("when the experimental slide feature is enabled", () => {
+    beforeEach(() => {
+      mockConfig.getUserConfig.mockResolvedValue({
+        includePrivate: false,
+        host: "localhost",
+        port: 8888,
+        experimentalSlideFeatureEnabled: true,
+      });
+    });
+
+    it("also watches the slide root", async () => {
+      await preview();
+
+      expect(mockGetSlideFileSystemRepo).toHaveBeenCalled();
+      expect(mockStartLocalChangeWatcher).toHaveBeenCalledWith({
+        server,
+        watchPaths: ["/data/public", "/data/slides"],
+      });
+    });
+  });
+});

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,4 +1,6 @@
+import { config } from "../lib/config";
 import { getFileSystemRepo } from "../lib/get-file-system-repo";
+import { getSlideFileSystemRepo } from "../lib/get-slide-file-system-repo";
 import { getQiitaApiInstance } from "../lib/get-qiita-api-instance";
 import { getUrlAddress } from "../lib/getUrlAddress";
 import { syncArticlesFromQiita } from "../lib/sync-articles-from-qiita";
@@ -7,6 +9,13 @@ import { startLocalChangeWatcher, startServer } from "../server/app";
 export const preview = async () => {
   const qiitaApi = await getQiitaApiInstance();
   const fileSystemRepo = await getFileSystemRepo();
+  const userConfig = await config.getUserConfig();
+  const watchPaths = [fileSystemRepo.getRootPath()];
+
+  if (userConfig.experimentalSlideFeatureEnabled) {
+    const slideFileSystemRepo = await getSlideFileSystemRepo();
+    watchPaths.push(slideFileSystemRepo.getRootPath());
+  }
 
   await syncArticlesFromQiita({ fileSystemRepo, qiitaApi });
 
@@ -22,6 +31,6 @@ export const preview = async () => {
 
   startLocalChangeWatcher({
     server,
-    watchPath: fileSystemRepo.getRootPath(),
+    watchPaths,
   });
 };

--- a/src/lib/check-slide-frontmatter-type.test.ts
+++ b/src/lib/check-slide-frontmatter-type.test.ts
@@ -1,0 +1,103 @@
+import { checkSlideFrontmatterType } from "./check-slide-frontmatter-type";
+
+describe("checkSlideFrontmatterType", () => {
+  const frontMatter = {
+    title: "Title",
+    id: null,
+    updatedAt: null,
+    description: null,
+  };
+
+  it("returns no errors", () => {
+    const errorMessages = checkSlideFrontmatterType(frontMatter);
+    expect(errorMessages).toEqual([]);
+  });
+
+  describe("checkTitle", () => {
+    describe("when title is null", () => {
+      it("returns no errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          title: null,
+        });
+        expect(errorMessages).toEqual([]);
+      });
+    });
+
+    describe("when title is a number", () => {
+      it("returns errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          title: 123 as unknown as string,
+        });
+        expect(errorMessages.length).toEqual(1);
+      });
+    });
+  });
+
+  describe("checkId", () => {
+    describe("when id is a string", () => {
+      it("returns no errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          id: "42dc00fafa166fa73d01",
+        });
+        expect(errorMessages).toEqual([]);
+      });
+    });
+
+    describe("when id is a number", () => {
+      it("returns errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          id: 123 as unknown as string,
+        });
+        expect(errorMessages.length).toEqual(1);
+      });
+    });
+  });
+
+  describe("checkUpdatedAt", () => {
+    describe("when updatedAt is null", () => {
+      it("returns no errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          updatedAt: null,
+        });
+        expect(errorMessages).toEqual([]);
+      });
+    });
+
+    describe("when updatedAt is a number", () => {
+      it("returns errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          updatedAt: 123 as unknown as string,
+        });
+        expect(errorMessages.length).toEqual(1);
+      });
+    });
+  });
+
+  describe("checkDescription", () => {
+    describe("when description is null", () => {
+      it("returns no errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          description: null,
+        });
+        expect(errorMessages).toEqual([]);
+      });
+    });
+
+    describe("when description is a number", () => {
+      it("returns errors", () => {
+        const errorMessages = checkSlideFrontmatterType({
+          ...frontMatter,
+          description: 123 as unknown as string,
+        });
+        expect(errorMessages.length).toEqual(1);
+      });
+    });
+  });
+});

--- a/src/lib/check-slide-frontmatter-type.ts
+++ b/src/lib/check-slide-frontmatter-type.ts
@@ -1,0 +1,63 @@
+interface SlideFrontMatter {
+  title: string | null;
+  id: string | null;
+  updatedAt: string | null;
+  description: string | null;
+}
+
+interface CheckType {
+  getMessage: (slide: SlideFrontMatter) => string;
+  isValid: (slide: SlideFrontMatter) => boolean;
+}
+
+export const checkSlideFrontmatterType = (
+  frontMatter: SlideFrontMatter,
+): string[] => {
+  const checkFrontMatterTypes = [
+    checkTitle,
+    checkId,
+    checkUpdatedAt,
+    checkDescription,
+  ];
+  return getErrorMessages(frontMatter, checkFrontMatterTypes);
+};
+
+const checkTitle: CheckType = {
+  getMessage: () => "titleは文字列で入力してください",
+  isValid: ({ title }) => {
+    return title === null || typeof title === "string";
+  },
+};
+
+const checkId: CheckType = {
+  getMessage: () => "idは文字列で入力してください",
+  isValid: ({ id }) => {
+    return id === null || typeof id === "string";
+  },
+};
+
+const checkUpdatedAt: CheckType = {
+  getMessage: () => "updated_atは文字列で入力してください",
+  isValid: ({ updatedAt }) => {
+    return updatedAt === null || typeof updatedAt === "string";
+  },
+};
+
+const checkDescription: CheckType = {
+  getMessage: () => "descriptionは文字列で入力してください",
+  isValid: ({ description }) => {
+    return description === null || typeof description === "string";
+  },
+};
+
+const getErrorMessages = (
+  frontMatter: SlideFrontMatter,
+  checkTypes: CheckType[],
+): string[] => {
+  return checkTypes.reduce((errorMessages: string[], checkType) => {
+    if (!checkType.isValid(frontMatter)) {
+      errorMessages.push(checkType.getMessage(frontMatter));
+    }
+    return errorMessages;
+  }, []);
+};

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -237,6 +237,25 @@ describe("config", () => {
           includePrivate: true,
           host: "localhost",
           port: 9999,
+          experimentalSlideFeatureEnabled: false,
+        });
+      });
+
+      describe("and it enables the experimental slide feature", () => {
+        beforeEach(() => {
+          const userConfigData = {
+            includePrivate: true,
+            host: "localhost",
+            port: 9999,
+            experimentalSlideFeatureEnabled: true,
+          };
+          resetFiles();
+          setFile(userConfigFilePath, JSON.stringify(userConfigData, null, 2));
+        });
+
+        it("returns experimentalSlideFeatureEnabled: true", async () => {
+          const userConfig = await config.getUserConfig();
+          expect(userConfig.experimentalSlideFeatureEnabled).toBe(true);
         });
       });
     });
@@ -252,6 +271,7 @@ describe("config", () => {
           includePrivate: false,
           host: "localhost",
           port: 8888,
+          experimentalSlideFeatureEnabled: false,
         });
       });
     });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,7 @@ type UserConfig = {
   includePrivate: boolean;
   host: string;
   port: number;
+  experimentalSlideFeatureEnabled: boolean;
 };
 
 class Config {
@@ -110,6 +111,7 @@ class Config {
       includePrivate: false,
       host: "localhost",
       port: 8888,
+      experimentalSlideFeatureEnabled: false,
     } as UserConfig;
 
     if (fsSync.existsSync(this.getUserConfigFilePath())) {

--- a/src/lib/entities/qiita-slide.ts
+++ b/src/lib/entities/qiita-slide.ts
@@ -1,0 +1,57 @@
+import matter from "gray-matter";
+
+export class QiitaSlide {
+  public readonly id: string | null;
+  public readonly title: string;
+  public readonly description: string | null;
+  public readonly rawBody: string;
+  public readonly updatedAt: string | null;
+  public readonly name: string;
+  public readonly slidesShowPath: string;
+  public readonly published: boolean;
+  public readonly slidePath: string;
+  public readonly marpFrontmatter: Record<string, unknown>;
+
+  constructor({
+    id,
+    title,
+    description,
+    rawBody,
+    updatedAt,
+    name,
+    slidesShowPath,
+    published,
+    slidePath,
+    marpFrontmatter,
+  }: {
+    id: string | null;
+    title: string;
+    description: string | null;
+    rawBody: string;
+    updatedAt: string | null;
+    name: string;
+    slidesShowPath: string;
+    published: boolean;
+    slidePath: string;
+    marpFrontmatter: Record<string, unknown>;
+  }) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+    this.rawBody = rawBody;
+    this.updatedAt = updatedAt;
+    this.name = name;
+    this.slidesShowPath = slidesShowPath;
+    this.published = published;
+    this.slidePath = slidePath;
+    this.marpFrontmatter = marpFrontmatter;
+  }
+
+  // The markdown handed to Qiita's slide preview API. Only the Marp
+  // directives (theme, paginate, ...) belong here — qiita-cli's own
+  // bookkeeping fields (id/updated_at/title/description) are not Marp
+  // directives, so they're deliberately left out.
+  toPreviewMarkdown(): string {
+    return matter.stringify(this.rawBody, this.marpFrontmatter);
+  }
+}

--- a/src/lib/get-slide-file-system-repo.ts
+++ b/src/lib/get-slide-file-system-repo.ts
@@ -1,0 +1,7 @@
+import { config } from "./config";
+import { SlideFileSystemRepo } from "./slide-file-system-repo";
+
+export const getSlideFileSystemRepo = async () =>
+  await SlideFileSystemRepo.build({
+    dataRootDir: config.getItemsRootDir(),
+  });

--- a/src/lib/qiita-cli-url.test.ts
+++ b/src/lib/qiita-cli-url.test.ts
@@ -2,8 +2,10 @@ import {
   apiItemsShowPath,
   apiItemsUpdatePath,
   apiReadmeShowPath,
+  apiSlidesShowPath,
   itemsIndexPath,
   itemsShowPath,
+  slidesShowPath,
 } from "./qiita-cli-url";
 
 describe("apiItemsShowPath", () => {
@@ -72,6 +74,44 @@ describe("itemsShowPath", () => {
     it("returns items show path", () => {
       const url = itemsShowPath(itemId, { basename: basename });
       expect(url).toEqual(`/items/${itemId}?basename=${basename}`);
+    });
+  });
+});
+
+describe("slidesShowPath", () => {
+  const slideId = "c686397e4a0f4f11683d";
+
+  it("returns slides show path", () => {
+    const url = slidesShowPath(slideId);
+    expect(url).toEqual(`/slides/${slideId}`);
+  });
+
+  describe("when slideId is 'show' and basename param exists", () => {
+    const slideId = "show";
+    const basename = "newSlide";
+
+    it("returns slides show path", () => {
+      const url = slidesShowPath(slideId, { basename: basename });
+      expect(url).toEqual(`/slides/${slideId}?basename=${basename}`);
+    });
+  });
+});
+
+describe("apiSlidesShowPath", () => {
+  const slideId = "c686397e4a0f4f11683d";
+
+  it("returns api slides show path", () => {
+    const url = apiSlidesShowPath(slideId);
+    expect(url).toEqual(`/api/slides/${slideId}`);
+  });
+
+  describe("when slideId is 'show' and basename param exists", () => {
+    const slideId = "show";
+    const basename = "newSlide";
+
+    it("returns api slides show path", () => {
+      const url = apiSlidesShowPath(slideId, { basename: basename });
+      expect(url).toEqual(`/api/slides/${slideId}?basename=${basename}`);
     });
   });
 });

--- a/src/lib/qiita-cli-url.ts
+++ b/src/lib/qiita-cli-url.ts
@@ -5,6 +5,36 @@ export const itemsIndexPath = () => {
   return "/";
 };
 
+export const slidesShowPath = (
+  slideId: string,
+  params?: ItemsShowQueryParams,
+): string => {
+  const url: string = `/slides/${slideId}`;
+
+  if (slideId === "show" && params) {
+    const query = new URLSearchParams(params).toString();
+
+    return `${url}?${query}`;
+  } else {
+    return url;
+  }
+};
+
+export const apiSlidesShowPath = (
+  slideId: string,
+  params?: ItemsShowQueryParams,
+): string => {
+  const url: string = `/api/slides/${slideId}`;
+
+  if (slideId === "show" && params) {
+    const query = new URLSearchParams(params).toString();
+
+    return `${url}?${query}`;
+  } else {
+    return url;
+  }
+};
+
 export const itemsShowPath = (
   itemId: string,
   params?: ItemsShowQueryParams,

--- a/src/lib/slide-file-system-repo.test.ts
+++ b/src/lib/slide-file-system-repo.test.ts
@@ -1,0 +1,260 @@
+import matter from "gray-matter";
+import fs from "node:fs/promises";
+import { SlideFileSystemRepo } from "./slide-file-system-repo";
+
+jest.mock("node:fs/promises");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SlideFileSystemRepo", () => {
+  describe("constructor", () => {
+    it("creates", () => {
+      const dataRootDir = "data_root_dir";
+      const subject = () => {
+        return new SlideFileSystemRepo({ dataRootDir });
+      };
+      expect(subject()).toBeInstanceOf(SlideFileSystemRepo);
+    });
+  });
+
+  describe("getRootPath()", () => {
+    it("returns the root path", () => {
+      const dataRootDir = "./tmp";
+      const instance = new SlideFileSystemRepo({ dataRootDir });
+      expect(instance.getRootPath()).toBe(`tmp/slides`);
+    });
+  });
+
+  describe("loadSlideByBasename()", () => {
+    it("returns null when not found", () => {
+      const mockFs = fs as jest.Mocked<typeof fs>;
+      mockFs.readdir.mockResolvedValueOnce([]);
+
+      const dataRootDir = "data_root_dir";
+      const subDir = "slides";
+      const instance = new SlideFileSystemRepo({ dataRootDir });
+      const basename = "abc";
+
+      return instance.loadSlideByBasename(basename).then((slide) => {
+        expect(slide).toBeNull();
+        expect(mockFs.readdir.mock.calls[0][0]).toBe(
+          `${dataRootDir}/${subDir}`,
+        );
+      });
+    });
+
+    describe("when found slide", () => {
+      it("returns unpublished slide when id is null", () => {
+        const dataRootDir = "data_root_dir";
+        const subDir = "slides";
+        const instance = new SlideFileSystemRepo({ dataRootDir });
+        const basename = "abc";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValue(`---
+title: Title
+id: null
+description: null
+---
+# Title`);
+
+        return instance.loadSlideByBasename(basename).then((slide) => {
+          expect(slide?.id).toBeNull();
+          expect(slide?.published).toBe(false);
+          expect(slide?.title).toBe("Title");
+          expect(slide?.slidesShowPath).toBe(
+            `/slides/show?basename=${basename}`,
+          );
+          expect(mockFs.readFile.mock.calls[0][0]).toBe(
+            `${dataRootDir}/${subDir}/${basename}.md`,
+          );
+        });
+      });
+
+      it("forwards arbitrary marp frontmatter (beyond theme) to the preview markdown", () => {
+        const dataRootDir = "data_root_dir";
+        const instance = new SlideFileSystemRepo({ dataRootDir });
+        const basename = "abc";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValue(`---
+title: Title
+id: null
+description: null
+theme: gaia
+paginate: true
+---
+# Title`);
+
+        return instance.loadSlideByBasename(basename).then((slide) => {
+          const { data, content } = matter(slide!.toPreviewMarkdown());
+          expect(data).toStrictEqual({ theme: "gaia", paginate: true });
+          expect(content.trim()).toBe("# Title");
+        });
+      });
+
+      it("returns published slide when id is present", () => {
+        const dataRootDir = "data_root_dir";
+        const instance = new SlideFileSystemRepo({ dataRootDir });
+        const basename = "abc";
+        const id = "this_is_id";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockResolvedValueOnce([`${basename}.md`] as any[]);
+        mockFs.readFile.mockResolvedValue(`---
+title: Title
+id: ${id}
+description: null
+---
+# Title`);
+
+        return instance.loadSlideByBasename(basename).then((slide) => {
+          expect(slide?.id).toBe(id);
+          expect(slide?.published).toBe(true);
+          expect(slide?.slidesShowPath).toBe(`/slides/${id}`);
+        });
+      });
+    });
+  });
+
+  describe("loadSlideById()", () => {
+    it("returns null when not found", () => {
+      const mockFs = fs as jest.Mocked<typeof fs>;
+      mockFs.readdir.mockResolvedValueOnce([]);
+
+      const instance = new SlideFileSystemRepo({
+        dataRootDir: "data_root_dir",
+      });
+
+      return instance.loadSlideById("missing-id").then((slide) => {
+        expect(slide).toBeNull();
+      });
+    });
+
+    describe("when found slide", () => {
+      it("returns the slide matching the id", () => {
+        const dataRootDir = "data_root_dir";
+        const subDir = "slides";
+        const instance = new SlideFileSystemRepo({ dataRootDir });
+        const id = "this_is_id";
+
+        const mockFs = fs as jest.Mocked<typeof fs>;
+        mockFs.readdir.mockImplementation(async (path) => {
+          switch (path) {
+            case `${dataRootDir}/${subDir}`:
+              return ["deck-a.md", "deck-b.md"] as any[];
+            default:
+              throw new Error(`Unexpected path: ${path}`);
+          }
+        });
+        mockFs.readFile.mockImplementation(async (path) => {
+          switch (path) {
+            case `${dataRootDir}/${subDir}/deck-a.md`:
+              return `---\ntitle: A\nid: other-id\ndescription: null\n---\nbody a`;
+            case `${dataRootDir}/${subDir}/deck-b.md`:
+              return `---\ntitle: B\nid: ${id}\ndescription: null\n---\nbody b`;
+            default:
+              throw new Error(`Unexpected path: ${path}`);
+          }
+        });
+
+        return instance.loadSlideById(id).then((slide) => {
+          expect(slide?.name).toBe("deck-b");
+          expect(slide?.id).toBe(id);
+        });
+      });
+    });
+  });
+
+  describe("loadSlides()", () => {
+    it("returns empty when no slides exist", () => {
+      const dataRootDir = "data_root_dir";
+      const subDir = "slides";
+      const instance = new SlideFileSystemRepo({ dataRootDir });
+
+      const mockFs = fs as jest.Mocked<typeof fs>;
+      mockFs.readdir.mockImplementation(async (path) => {
+        switch (path) {
+          case `${dataRootDir}/${subDir}`:
+            return [];
+          default:
+            throw new Error(`Unexpected path: ${path}`);
+        }
+      });
+
+      return instance.loadSlides().then((slides) => {
+        expect(slides).toStrictEqual([]);
+      });
+    });
+
+    it("returns all slides", () => {
+      const dataRootDir = "data_root_dir";
+      const subDir = "slides";
+      const instance = new SlideFileSystemRepo({ dataRootDir });
+
+      const mockFs = fs as jest.Mocked<typeof fs>;
+      mockFs.readdir.mockImplementation(async (path) => {
+        switch (path) {
+          case `${dataRootDir}/${subDir}`:
+            return ["deck-a.md", "deck-b.md"] as any[];
+          default:
+            throw new Error(`Unexpected path: ${path}`);
+        }
+      });
+      mockFs.readFile.mockImplementation(async (path) => {
+        switch (path) {
+          case `${dataRootDir}/${subDir}/deck-a.md`:
+            return `---\ntitle: A\nid: id-a\ndescription: null\n---\nbody a`;
+          case `${dataRootDir}/${subDir}/deck-b.md`:
+            return `---\ntitle: B\nid: id-b\ndescription: null\n---\nbody b`;
+          default:
+            throw new Error(`Unexpected path: ${path}`);
+        }
+      });
+
+      return instance.loadSlides().then((slides) => {
+        expect(slides.map((slide) => slide.id)).toStrictEqual(["id-a", "id-b"]);
+      });
+    });
+  });
+
+  describe("createSlide()", () => {
+    it("saves slide with a default basename when basename is not given", () => {
+      const mockFs = fs as jest.Mocked<typeof fs>;
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockFs.writeFile.mockResolvedValueOnce();
+
+      const dataRootDir = "data_root_dir";
+      const subDir = "slides";
+      const instance = new SlideFileSystemRepo({ dataRootDir });
+
+      return instance.createSlide().then(() => {
+        expect(mockFs.writeFile.mock.calls[0][0]).toBe(
+          `${dataRootDir}/${subDir}/newSlide001.md`,
+        );
+        const { data } = matter(mockFs.writeFile.mock.calls[0][1] as string);
+        expect(data.id).toBeNull();
+      });
+    });
+
+    it("saves slide with the given basename", () => {
+      const mockFs = fs as jest.Mocked<typeof fs>;
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockFs.writeFile.mockResolvedValueOnce();
+
+      const dataRootDir = "data_root_dir";
+      const subDir = "slides";
+      const instance = new SlideFileSystemRepo({ dataRootDir });
+
+      return instance.createSlide("deck").then(() => {
+        expect(mockFs.writeFile.mock.calls[0][0]).toBe(
+          `${dataRootDir}/${subDir}/deck.md`,
+        );
+      });
+    });
+  });
+});

--- a/src/lib/slide-file-system-repo.ts
+++ b/src/lib/slide-file-system-repo.ts
@@ -1,0 +1,242 @@
+import matter from "gray-matter";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { slidesShowPath } from "./qiita-cli-url";
+import { QiitaSlide } from "./entities/qiita-slide";
+
+// Fields qiita-cli itself manages in the frontmatter. Everything else is an
+// arbitrary Marp directive (theme, paginate, header, class, ...) that we don't
+// need to know the shape of — it's just carried through to the slide preview.
+const RESERVED_FRONTMATTER_KEYS = ["title", "id", "updated_at", "description"];
+
+class SlideFileContent {
+  public readonly title: string;
+  public readonly id: string | null;
+  public readonly updatedAt: string | null;
+  public readonly description: string | null;
+  public readonly rawBody: string;
+  public readonly marpFrontmatter: Record<string, unknown>;
+
+  constructor({
+    title,
+    id,
+    updatedAt,
+    description,
+    rawBody,
+    marpFrontmatter,
+  }: {
+    title: string;
+    id: string | null;
+    updatedAt: string | null;
+    description: string | null;
+    rawBody: string;
+    marpFrontmatter: Record<string, unknown>;
+  }) {
+    this.title = title;
+    this.id = id;
+    this.updatedAt = updatedAt;
+    this.description = description;
+    this.rawBody = rawBody;
+    this.marpFrontmatter = marpFrontmatter;
+  }
+
+  static read(fileContent: string): SlideFileContent {
+    const { data, content } = matter(fileContent);
+    const marpFrontmatter = Object.fromEntries(
+      Object.entries(data).filter(
+        ([key]) => !RESERVED_FRONTMATTER_KEYS.includes(key),
+      ),
+    );
+
+    return new SlideFileContent({
+      rawBody: content,
+      title: data.title,
+      id: data.id,
+      updatedAt: data.updated_at,
+      description: data.description,
+      marpFrontmatter,
+    });
+  }
+
+  static empty({ title }: { title: string }): SlideFileContent {
+    return new SlideFileContent({
+      rawBody: "# Title\n\n---\n\n# Page 2",
+      title,
+      id: null,
+      updatedAt: null,
+      description: "",
+      marpFrontmatter: { marp: true, theme: "default" },
+    });
+  }
+
+  toSaveFormat(): string {
+    return matter.stringify(this.rawBody, {
+      title: this.title,
+      id: this.id,
+      updated_at: this.updatedAt,
+      description: this.description,
+      ...this.marpFrontmatter,
+    });
+  }
+}
+
+export class SlideFileSystemRepo {
+  private readonly dataRootDir: string;
+
+  constructor({ dataRootDir }: { dataRootDir: string }) {
+    this.dataRootDir = dataRootDir;
+  }
+
+  public static async build({ dataRootDir }: { dataRootDir: string }) {
+    const slideFileSystemRepo = new SlideFileSystemRepo({ dataRootDir });
+    await slideFileSystemRepo.setUp();
+
+    return slideFileSystemRepo;
+  }
+
+  private async setUp() {
+    await fs.mkdir(this.getRootPath(), { recursive: true });
+  }
+
+  public getRootPath() {
+    const subdir = "slides";
+    return path.join(this.dataRootDir, subdir);
+  }
+
+  private getFilename(basename: string) {
+    return `${basename}.md`;
+  }
+
+  private parseFilename(filename: string) {
+    return filename.replace(/\.md$/, "");
+  }
+
+  private getFilePath(basename: string) {
+    return path.join(this.getRootPath(), this.getFilename(basename));
+  }
+
+  private async getSlideFilenames() {
+    return (
+      await fs.readdir(
+        this.getRootPath(),
+        SlideFileSystemRepo.fileSystemOptions(),
+      )
+    ).filter((filename) => /\.md$/.test(filename));
+  }
+
+  private async getNewBasename() {
+    const prefix = "newSlide";
+    const filenames = await this.getSlideFilenames();
+    const limit = 999;
+    for (let i = 1; i <= limit; ++i) {
+      const suffix = i.toString().padStart(3, "0");
+      const basename = `${prefix}${suffix}`;
+      const filenameCandidate = this.getFilename(basename);
+      const found = filenames.find(
+        (filename) => filename === filenameCandidate,
+      );
+      if (!found) {
+        return basename;
+      }
+    }
+    return;
+  }
+
+  private static fileSystemOptions() {
+    return {
+      encoding: "utf8",
+      withFileTypes: false,
+      recursive: true,
+    } as const;
+  }
+
+  private async getSlideData(
+    filename: string,
+  ): Promise<SlideFileContent | null> {
+    try {
+      const fileContent = await fs.readFile(
+        path.join(this.getRootPath(), filename),
+        SlideFileSystemRepo.fileSystemOptions(),
+      );
+      return SlideFileContent.read(fileContent);
+    } catch {
+      return null;
+    }
+  }
+
+  async loadSlides(): Promise<QiitaSlide[]> {
+    const filenames = await this.getSlideFilenames();
+
+    const promises = filenames.map(async (filename) => {
+      const basename = this.parseFilename(filename);
+      return await this.loadSlideByBasename(basename);
+    });
+
+    return excludeNull(await Promise.all(promises));
+  }
+
+  async loadSlideByBasename(basename: string): Promise<QiitaSlide | null> {
+    const filenames = await this.getSlideFilenames();
+    const filename = this.getFilename(basename);
+
+    if (!filenames.includes(filename)) {
+      return null;
+    }
+
+    const slidePath = this.getFilePath(basename);
+    const fileContent = await this.getSlideData(filename);
+    if (!fileContent) {
+      return null;
+    }
+
+    return new QiitaSlide({
+      id: fileContent.id,
+      title: fileContent.title,
+      description: fileContent.description,
+      rawBody: fileContent.rawBody,
+      updatedAt: fileContent.updatedAt,
+      name: basename,
+      slidesShowPath: this.generateSlidesShowPath(fileContent.id, basename),
+      published: fileContent.id !== null,
+      slidePath,
+      marpFrontmatter: fileContent.marpFrontmatter,
+    });
+  }
+
+  async loadSlideById(id: string): Promise<QiitaSlide | null> {
+    const filenames = await this.getSlideFilenames();
+
+    for (const filename of filenames) {
+      const fileContent = await this.getSlideData(filename);
+      if (fileContent?.id === id) {
+        return this.loadSlideByBasename(this.parseFilename(filename));
+      }
+    }
+
+    return null;
+  }
+
+  async createSlide(basename?: string) {
+    basename = basename || (await this.getNewBasename());
+    if (!basename) return;
+    const slide = await this.loadSlideByBasename(basename);
+    if (slide) return;
+
+    const filepath = this.getFilePath(basename);
+    const newFileContent = SlideFileContent.empty({ title: basename });
+    const data = newFileContent.toSaveFormat();
+    await fs.writeFile(filepath, data, SlideFileSystemRepo.fileSystemOptions());
+    return basename;
+  }
+
+  // FIXME: Move outside of "repository"
+  private generateSlidesShowPath(slideId: string | null, basename: string) {
+    return slideId
+      ? slidesShowPath(slideId)
+      : slidesShowPath("show", { basename });
+  }
+}
+
+const excludeNull = <T>(array: (T | null)[]): T[] => {
+  return array.filter((val): val is T => val !== null);
+};

--- a/src/lib/validators/slide-validator.test.ts
+++ b/src/lib/validators/slide-validator.test.ts
@@ -1,0 +1,53 @@
+import { validateSlide } from "./slide-validator";
+
+describe("validateSlide", () => {
+  const slide = {
+    title: "Title",
+    rawBody: "Slide body",
+  };
+
+  it("returns no errors", () => {
+    const errorMessages = validateSlide(slide);
+    expect(errorMessages).toEqual([]);
+  });
+
+  describe("validateSlideTitle", () => {
+    describe("when title is null", () => {
+      const errorMessages = validateSlide({ ...slide, title: null });
+
+      it("returns validation error message", () => {
+        expect(errorMessages.length).toEqual(1);
+        expect(errorMessages[0]).toContain("タイトルを入力してください");
+      });
+    });
+
+    describe("when title is empty", () => {
+      const errorMessages = validateSlide({ ...slide, title: "" });
+
+      it("returns validation error message", () => {
+        expect(errorMessages.length).toEqual(1);
+        expect(errorMessages[0]).toContain("タイトルを入力してください");
+      });
+    });
+  });
+
+  describe("validateSlideRawBody", () => {
+    describe("when rawBody is null", () => {
+      const errorMessages = validateSlide({ ...slide, rawBody: null });
+
+      it("returns validation error message", () => {
+        expect(errorMessages.length).toEqual(1);
+        expect(errorMessages[0]).toContain("本文を入力してください");
+      });
+    });
+
+    describe("when rawBody is empty", () => {
+      const errorMessages = validateSlide({ ...slide, rawBody: "" });
+
+      it("returns validation error message", () => {
+        expect(errorMessages.length).toEqual(1);
+        expect(errorMessages[0]).toContain("本文を入力してください");
+      });
+    });
+  });
+});

--- a/src/lib/validators/slide-validator.ts
+++ b/src/lib/validators/slide-validator.ts
@@ -1,0 +1,42 @@
+interface Slide {
+  title: string | null;
+  rawBody: string | null;
+}
+
+interface Validator {
+  getMessage: (slide: Slide) => string;
+  isValid: (slide: Slide) => boolean;
+}
+
+export const validateSlide = (slide: Slide): string[] => {
+  const validators = [validateSlideTitle, validateSlideRawBody];
+  return getValidationErrorMessages(slide, validators);
+};
+
+const validateSlideTitle: Validator = {
+  getMessage: () => "タイトルを入力してください",
+  isValid: ({ title }) => {
+    if (!title) return false;
+    return title.length > 0;
+  },
+};
+
+const validateSlideRawBody: Validator = {
+  getMessage: () => "本文を入力してください",
+  isValid: ({ rawBody }) => {
+    if (!rawBody) return false;
+    return rawBody.length > 0;
+  },
+};
+
+const getValidationErrorMessages = (
+  slide: Slide,
+  validators: Validator[],
+): string[] => {
+  return validators.reduce((errorMessages: string[], validator) => {
+    if (!validator.isValid(slide)) {
+      errorMessages.push(validator.getMessage(slide));
+    }
+    return errorMessages;
+  }, []);
+};

--- a/src/lib/view-models/slides.ts
+++ b/src/lib/view-models/slides.ts
@@ -1,0 +1,24 @@
+export type SlidesShowViewModel = {
+  title: string;
+  pages: { html: string; speaker_note: string[] }[];
+  css: string;
+  error_messages: string[];
+  slides_show_path: string;
+  slide_path: string;
+  published: boolean;
+  theme: string | null;
+};
+
+export type SlideViewModel = {
+  id: string | null;
+  name: string;
+  title: string;
+  updated_at: string | null;
+  slides_show_path: string;
+  published: boolean;
+};
+
+export type SlidesIndexViewModel = {
+  draft: SlideViewModel[];
+  published: SlideViewModel[];
+};

--- a/src/qiita-api/index.ts
+++ b/src/qiita-api/index.ts
@@ -30,6 +30,11 @@ export interface Item {
   posting_campaign_uuid: string | null;
 }
 
+export interface SlidePreview {
+  pages: { html: string; speaker_note: string[] }[];
+  css: string;
+}
+
 export interface PostingCampaign {
   uuid: string;
   title: string;
@@ -293,6 +298,16 @@ export class QiitaApi {
     const path = `/api/v2/items/${uuid}`;
 
     return await this.patch<Item>(path, {
+      body: data,
+    });
+  }
+
+  async previewSlide(rawBody: string) {
+    const data = JSON.stringify({
+      body: rawBody,
+    });
+
+    return await this.post<SlidePreview>(`/api/v2/slide_previews`, {
       body: data,
     });
   }

--- a/src/server/api/slides.ts
+++ b/src/server/api/slides.ts
@@ -1,0 +1,101 @@
+import type Express from "express";
+import { Router } from "express";
+import { checkSlideFrontmatterType } from "../../lib/check-slide-frontmatter-type";
+import { getSlideFileSystemRepo } from "../../lib/get-slide-file-system-repo";
+import { getQiitaApiInstance } from "../../lib/get-qiita-api-instance";
+import { validateSlide } from "../../lib/validators/slide-validator";
+import type {
+  SlideViewModel,
+  SlidesIndexViewModel,
+  SlidesShowViewModel,
+} from "../../lib/view-models/slides";
+
+const slidesIndex = async (req: Express.Request, res: Express.Response) => {
+  const slideFileSystemRepo = await getSlideFileSystemRepo();
+
+  const slideData = await slideFileSystemRepo.loadSlides();
+
+  const result: SlidesIndexViewModel = slideData.reduce(
+    (prev, slide) => {
+      const resultSlide: SlideViewModel = {
+        id: slide.id,
+        name: slide.name,
+        title: slide.title,
+        updated_at: slide.updatedAt,
+        slides_show_path: slide.slidesShowPath,
+        published: slide.published,
+      };
+
+      if (slide.published) {
+        prev.published.push(resultSlide);
+      } else {
+        prev.draft.push(resultSlide);
+      }
+      return prev;
+    },
+    {
+      draft: [] as SlideViewModel[],
+      published: [] as SlideViewModel[],
+    },
+  );
+
+  res.json(result);
+};
+
+const slidesCreate = async (req: Express.Request, res: Express.Response) => {
+  const slideFileSystemRepo = await getSlideFileSystemRepo();
+
+  const basename = await slideFileSystemRepo.createSlide();
+
+  res.json({ basename });
+};
+
+const slidesShow = async (req: Express.Request, res: Express.Response) => {
+  const slideId = req.params.id;
+  const basename = req.query.basename as string | undefined;
+
+  const slideFileSystemRepo = await getSlideFileSystemRepo();
+
+  const slide =
+    slideId === "show" && basename
+      ? await slideFileSystemRepo.loadSlideByBasename(basename)
+      : await slideFileSystemRepo.loadSlideById(slideId);
+
+  if (!slide) {
+    res.status(404).json({
+      message: "Not found",
+    });
+    return;
+  }
+
+  const errorFrontmatterMessages = checkSlideFrontmatterType(slide);
+  if (errorFrontmatterMessages.length > 0) {
+    res.status(500).json({
+      errorMessages: errorFrontmatterMessages,
+    });
+    return;
+  }
+
+  const qiitaApi = await getQiitaApiInstance();
+  const { pages, css } = await qiitaApi.previewSlide(slide.toPreviewMarkdown());
+
+  const result: SlidesShowViewModel = {
+    title: slide.title,
+    pages,
+    css,
+    error_messages: validateSlide(slide),
+    slides_show_path: slide.slidesShowPath,
+    slide_path: slide.slidePath,
+    published: slide.published,
+    theme:
+      typeof slide.marpFrontmatter.theme === "string"
+        ? slide.marpFrontmatter.theme
+        : null,
+  };
+  res.json(result);
+};
+
+export const SlidesRouter = Router()
+  .get("/", slidesIndex)
+  .post("/", slidesCreate)
+  .get("/:id", slidesShow);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -9,11 +9,13 @@ import { AssetsRouter } from "./api/assets";
 import { EmojiRouter } from "./api/emoji";
 import { ItemsRouter } from "./api/items";
 import { ReadmeRouter } from "./api/readme";
+import { SlidesRouter } from "./api/slides";
 import { config } from "../lib/config";
 import { getUrlAddress } from "../lib/getUrlAddress";
 
 export async function startServer() {
   const app = express();
+  const userConfig = await config.getUserConfig();
 
   app.use(express.json());
 
@@ -25,17 +27,22 @@ export async function startServer() {
   app.use(express.static(path.join(__dirname, "../public")));
 
   app.use("/api/items", ItemsRouter);
+  if (userConfig.experimentalSlideFeatureEnabled) {
+    app.use("/api/slides", SlidesRouter);
+  } else {
+    app.use("/api/slides", (req, res) => {
+      res.status(404).json({ message: "Not found" });
+    });
+  }
   app.use("/api/readme", ReadmeRouter);
   app.use("/assets", AssetsRouter);
   app.use("/emoji", EmojiRouter);
 
-  app.use(
-    "*name",
-    express.static(path.join(__dirname, "../public/index.html")),
-  );
+  app.use("*name", (req, res) => {
+    res.sendFile(path.join(__dirname, "../public/index.html"));
+  });
 
   const server = createServer(app);
-  const userConfig = await config.getUserConfig();
   const port = userConfig.port;
   const host = userConfig.host;
 
@@ -59,20 +66,23 @@ export async function startServer() {
 
 export function startLocalChangeWatcher({
   server,
-  watchPath,
+  watchPaths,
 }: {
   server: Server;
-  watchPath: string;
+  watchPaths: string | string[];
 }) {
   const wsServer = new WebSocketServer({ server });
-  const watcher = chokidar.watch(watchPath, {
+  const watcher = chokidar.watch(watchPaths, {
     ignored: [/node_modules|\.git/, "**/.remote/**"],
   });
-  watcher.on("change", () => {
+  const notifyClients = () => {
     wsServer.clients.forEach((client) => {
       if (client.readyState === WebSocket.OPEN) {
         client.send("local changed");
       }
     });
-  });
+  };
+  watcher.on("change", notifyClients);
+  watcher.on("add", notifyClients);
+  watcher.on("unlink", notifyClients);
 }


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

記事(item)に加えて、Marp 形式のスライドをローカルでプレビューできる機能を実験的機能として追加する。見た目や画面構成の詳細は Screenshot を参照。

- スライドは新設した `slides/` ディレクトリの中に、記事とは別の Markdown ファイルとして1つずつ保存する。それに対応する `QiitaSlide` エンティティ、`SlideFileSystemRepo` を追加
- `qiita new --slide` でスライドの雛形を追加できるようにする(`marp: true` / `theme: default` を含むフロントマターで生成)
- `qiita preview` にスライド用のルート(`/slides/:id`, `/api/slides`)とサイドバーの Slides セクションを追加する
- スライドのフロントマターのうち `title`/`id`/`updated_at`/`description`(qiita-cli 自身が管理する項目)以外 ── `theme` や `paginate` などの任意の Marp ディレクティブ ── は、そのままプレビュー用 API に転送する

これらはすべて `qiita.config.json` の `experimentalSlideFeatureEnabled`(デフォルト `false`)の下で opt-in にしている。無効時は `qiita new --slide` はヒントを出して終了し、`/api/slides` は404を返し、サイドバーに Slides セクションは表示されない。`qiita preview` の `slides/` ディレクトリの作成・監視もフラグが無効な間は行わない。

あわせて、記事(item)側にも影響する既存の不具合を2件修正した。

- SPA の catch-all ルートが `express.static` にファイルパスを渡していたため、`/items/:id` (および今回追加する `/slides/:id`) へ直接アクセス(フルページ遷移)すると404になっていた点を `res.sendFile` を使うよう修正
- `embed_init_js_url` の読み込みに失敗して `window.qiitaEmbedInit` が undefined になった場合、client バンドル全体がクラッシュしていた点をガードして修正

## How

既存の記事(item)向けの実装パターン(FileSystemRepo・プレビュー用ページ・ルーティング)をなるべく踏襲しつつ、スライド専用の entity/repo/route/component を独立して追加した。

Marp によるレンダリング自体は Qiita 側の API に任せ、CLI 側は返ってきた HTML/CSS を Shadow DOM に流し込むだけにすることで、Marp が生成するグローバルな CSS セレクタがアプリ本体に漏れないようにしている。フロントマターは `title`/`id`/`updated_at`/`description` だけを qiita-cli 側の型として読み取り、それ以外のキーは丸ごと `marpFrontmatter` として保持してプレビュー用 markdown の先頭に付け直すことで、どんな Marp ディレクティブでも qiita-cli 側の実装を変更せずに転送できるようにした。

また、ローカルファイル変更の検知(watcher)が単一ディレクトリしか見ていなかったため、複数ディレクトリ(記事とスライド)を watch できるように拡張し、ファイルの追加/削除にも追随するようにした。

## Why

記事に加えてスライドも、公開前にローカルで見た目を確認しながら書けるようにしたい、というのが動機。

当初は `qiita publish` でのスライドの投稿・更新(post/patch)まで一つの PR に含めていたが、プレビュー機能と一緒にレビューするとレビューコストが上がるため、この PR はローカルプレビューに絞り、投稿・更新は別 PR に切り出すことにした(`qiita new --slide` によるスライド作成とローカルプレビューはこの PR で完結して利用できる)。

スライド詳細画面は当初、クリック/矢印キーで1枚ずつ送るプレゼンテーション形式をデフォルトにしていたが、内容を確認するだけの用途には使いづらかったため、記事プレビューと同じ「スクロールして全体を見る」形式をデフォルトにし、プレゼンテーション表示はオプションの導線に変更した(詳細は Screenshot 参照)。

まだ実験段階の機能のため、既存ユーザーの体験に影響を与えないよう `experimentalSlideFeatureEnabled` フラグの下に隠している。

## 動作確認

`npm run lint` / `npm run build` / `npm test`(136 tests)はいずれも pass。

`qiita.config.json` で `experimentalSlideFeatureEnabled: true` にした状態で、ブラウザおよび Playwright(`.playwright-tests/`)で以下を確認済み。

- `qiita new --slide` によるスライド作成(`marp: true` / `theme: default` を含むフロントマターで生成されること)
- プレビュー画面でのスライド表示、サイドバーの Slides セクションからの遷移
- フロントマターに `theme: gaia` を設定した場合に、実際に Gaia テーマの見た目(背景・フォント)が反映されること
- フロントマター不備時のバリデーションエラー表示
- 機能を無効にした状態で `qiita new --slide` がヒントを出して終了すること、`/api/slides` が404になること、`slides/` ディレクトリが作成・監視されないこと

## Screenshot

Playwright(`.playwright-tests/`, `npx playwright test`, Base URL `http://localhost:8888`)で動作確認し、スクリーンショットを撮影しました。

**サイドバーの Slides セクション**(下書き/公開済みの一覧、新規作成ボタン)

![sidebar](https://github.com/user-attachments/assets/2172e463-2e37-43d6-b080-3f9ba9392736)

**スライド詳細画面**。記事プレビューと同じツールバー(ファイルパス表示、プレゼンテーションモードへの導線)を持つ。「スライド情報」パネル(タイトル・テーマ・投稿状態・ページ数を表示、クリックで開閉)を開いた状態。プレゼンテーション形式ではなく、全ページを縦に並べたスタック表示がデフォルトになっている。

![slide detail](https://github.com/user-attachments/assets/5fdf76fd-496b-476e-8011-196aaee19c99)

**プレゼンテーションモード**。ツールバーの「プレゼンテーションモードで開く」から新しいタブで開き、従来通りクリック/矢印キーで1枚ずつ送る全画面表示になる。

![presentation mode](https://github.com/user-attachments/assets/593156d1-3323-4b36-821a-9193fc529400)

**フロントマター不備時のバリデーションエラー表示**。タイトル未設定など必須項目が欠けている場合、スライド情報パネルの下にエラーバナーが出る。

![validation error](https://github.com/user-attachments/assets/a2a00d77-7346-4af5-a3e9-88b3a33473bb)
