### PR TITLE
Support overriding asset URLs with environment variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,8 @@ QIITA_TOKEN='<Qiita トークン>'
 QIITA_CLI_ITEMS_ROOT="./tmp"
 XDG_CONFIG_HOME="./tmp"
 XDG_CACHE_HOME="./tmp/.cache"
+
+# Optional asset URL overrides for development
+# QIITA_ASSETS_ARTICLE_CSS="https://example.test/article.css"
+# QIITA_ASSETS_EMBED_INIT_JS="https://example.test/embed-init.js"
+# QIITA_ASSETS_FAVICON="https://example.test/favicon.ico"

--- a/src/server/api/assets.test.ts
+++ b/src/server/api/assets.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { getQiitaApiInstance } from "../../lib/get-qiita-api-instance";
+import { QiitaApi } from "../../qiita-api";
+import { AssetsRouter } from "./assets";
+
+jest.mock("../../lib/get-qiita-api-instance");
+
+const mockGetQiitaApiInstance = jest.mocked(getQiitaApiInstance);
+
+const assetEnvironmentVariables = [
+  "QIITA_ASSETS_ARTICLE_CSS",
+  "QIITA_ASSETS_EMBED_INIT_JS",
+  "QIITA_ASSETS_FAVICON",
+] as const;
+
+describe("AssetsRouter", () => {
+  let server: Server;
+  let baseUrl: string;
+  const originalEnvironment = Object.fromEntries(
+    assetEnvironmentVariables.map((name) => [name, process.env[name]]),
+  );
+
+  beforeAll(async () => {
+    const app = express();
+    app.use("/assets", AssetsRouter);
+    server = createServer(app);
+
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+      server.once("error", reject);
+    });
+
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    for (const name of assetEnvironmentVariables) {
+      const value = originalEnvironment[name];
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const name of assetEnvironmentVariables) {
+      delete process.env[name];
+    }
+  });
+
+  it("uses each configured asset URL and falls back to the API URLs", async () => {
+    const overrides = {
+      QIITA_ASSETS_ARTICLE_CSS: "https://dev.example/article.css",
+      QIITA_ASSETS_EMBED_INIT_JS: "https://dev.example/embed-init.js",
+      QIITA_ASSETS_FAVICON: "https://dev.example/favicon.ico",
+    };
+    Object.assign(process.env, overrides);
+
+    await expectRedirect(
+      "/assets/article.css",
+      overrides.QIITA_ASSETS_ARTICLE_CSS,
+    );
+    await expectRedirect(
+      "/assets/embed-init.js",
+      overrides.QIITA_ASSETS_EMBED_INIT_JS,
+    );
+    await expectRedirect("/assets/favicon.ico", overrides.QIITA_ASSETS_FAVICON);
+    expect(mockGetQiitaApiInstance).not.toHaveBeenCalled();
+
+    const getAssetUrls = jest.fn().mockResolvedValue({
+      article_css_url: "https://cdn.example/article.css",
+      v3_embed_init_js_url: "https://cdn.example/embed-init.js",
+      favicon_url: "https://cdn.example/favicon.ico",
+    });
+    mockGetQiitaApiInstance.mockResolvedValue({
+      getAssetUrls,
+    } as unknown as QiitaApi);
+
+    for (const name of assetEnvironmentVariables) {
+      process.env[name] = "";
+    }
+
+    await expectRedirect(
+      "/assets/article.css",
+      "https://cdn.example/article.css",
+    );
+    await expectRedirect(
+      "/assets/embed-init.js",
+      "https://cdn.example/embed-init.js",
+    );
+    await expectRedirect(
+      "/assets/favicon.ico",
+      "https://cdn.example/favicon.ico",
+    );
+    expect(mockGetQiitaApiInstance).toHaveBeenCalledTimes(1);
+    expect(getAssetUrls).toHaveBeenCalledTimes(1);
+
+    process.env.QIITA_ASSETS_ARTICLE_CSS = "https://dev.example/partial.css";
+    await expectRedirect(
+      "/assets/article.css",
+      "https://dev.example/partial.css",
+    );
+    await expectRedirect(
+      "/assets/embed-init.js",
+      "https://cdn.example/embed-init.js",
+    );
+    await expectRedirect(
+      "/assets/favicon.ico",
+      "https://cdn.example/favicon.ico",
+    );
+    expect(mockGetQiitaApiInstance).toHaveBeenCalledTimes(1);
+  });
+
+  const expectRedirect = async (path: string, location: string) => {
+    const response = await fetch(`${baseUrl}${path}`, {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(location);
+  };
+});

--- a/src/server/api/assets.ts
+++ b/src/server/api/assets.ts
@@ -6,7 +6,9 @@ const redirectToArticleCss = async (
   req: Express.Request,
   res: Express.Response,
 ) => {
-  const url = await resolveAssetsUrl("article_css_url");
+  const url =
+    process.env.QIITA_ASSETS_ARTICLE_CSS ||
+    (await resolveAssetsUrl("article_css_url"));
   res.redirect(url);
 };
 
@@ -14,7 +16,9 @@ const redirectToEmbedInitJs = async (
   req: Express.Request,
   res: Express.Response,
 ) => {
-  const url = await resolveAssetsUrl("v3_embed_init_js_url");
+  const url =
+    process.env.QIITA_ASSETS_EMBED_INIT_JS ||
+    (await resolveAssetsUrl("v3_embed_init_js_url"));
   res.redirect(url);
 };
 
@@ -22,7 +26,8 @@ const redirectToFavicon = async (
   req: Express.Request,
   res: Express.Response,
 ) => {
-  const url = await resolveAssetsUrl("favicon_url");
+  const url =
+    process.env.QIITA_ASSETS_FAVICON || (await resolveAssetsUrl("favicon_url"));
   res.redirect(url);
 };
 


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->

## What

`qiita preview` の `article.css`、`embed-init.js`、favicon の取得先を、環境変数で個別に上書きできるようにする。

## How

各アセットに対応する環境変数をリダイレクト時に優先し、未設定または空文字の場合は既存の Qiita API から取得した URLへフォールバックする。
ルーターの HTTP テストで、3アセットの上書き・フォールバック・混在利用と API キャッシュを検証した。

## Why

開発環境で Qiita アセットの取得先を差し替えて確認できるようにしたい。

## Refs
